### PR TITLE
encapsulates MPI support

### DIFF
--- a/AbcMPI.cpp
+++ b/AbcMPI.cpp
@@ -1,0 +1,147 @@
+
+#include "AbcMPI.h" // pre declarations for MPI functions / types
+
+// TODO is there a way to capture this approach in AbcSim?
+// As with those functors, this is largely a wrapper around a function pointer
+
+namespace ABC {
+    void particle_scheduler(
+        Mat2D &X_orig, // metrics - should be properly sized in advance, to be filled in by this function
+        const Mat2D &Y_orig, // parameters - should be filled in advance (e.g. by sample_priors)
+        MPI_par *_mp
+    ) {
+#ifdef USING_MPI
+        MPI_Status status;
+        assert(X_orig.rows() == Y_orig.rows());
+
+        auto *send_data = new long double[Y_orig.size()](); // all params, flattened array
+        auto *rec_data  = new long double[X_orig.size()](); // all metrics, flattened array
+
+        const size_t _num_particles = Y_orig.rows();
+        const size_t npar = Y_orig.cols();
+        const size_t nmet = X_orig.cols();
+
+        // sample parameter distributions; copy values into Y matrix and into send_data buffer
+        for (size_t i = 0; i < _num_particles; i++) {
+            for (size_t j = 0; j < npar; j++) { send_data[i*npar + j] = Y_orig(i, j); }
+        }
+        // Seed the workers with the first 'num_workers' jobs
+        int particle_id = 0;
+        // Don't send particles that don't exist!
+        for (int rank = 1; (rank < _mp->mpi_size) and (rank <= _num_particles); ++rank) {
+            particle_id = rank - 1;                       // which row in Y
+            MPI_Send(&send_data[particle_id*npar],  // message buffer
+                    npar,                          // number of elements
+                    MPI_LONG_DOUBLE,                 // data item is a double
+                    rank,                            // destination process rank
+                    particle_id,                     // message tag
+                    _mp->comm);                      // always use this
+        }
+
+        // Receive a result from any worker and dispatch a new work request
+        long double rec_buffer[nmet];
+        particle_id++; // move cursor to next particle to be sent
+        while ( particle_id < _num_particles ) {
+            MPI_Recv(&rec_buffer,                     // message buffer
+                    nmet,                          // message size
+                    MPI_LONG_DOUBLE,                 // of type double
+                    MPI_ANY_SOURCE,                  // receive from any sender
+                    MPI_ANY_TAG,                     // any type of message
+                    _mp->comm,                       // always use this
+                    &status);                        // received message info
+            for (int m = 0; m<nmet; ++m) rec_data[status.MPI_TAG*nmet + m] = rec_buffer[m];
+
+            MPI_Send(&send_data[particle_id*npar],  // message buffer
+                    npar,                          // number of elements
+                    MPI_LONG_DOUBLE,                 // data item is a double
+                    status.MPI_SOURCE,               // send it to the rank that just finished
+                    particle_id,                     // message tag
+                    _mp->comm);                      // always use this
+            particle_id++; // move cursor
+        }
+
+        // receive results for outstanding work requests--there are exactly 'num_workers'
+        // or '_num_particles' left, whichever is smaller
+        for (int rank = 1; (rank < _mp->mpi_size) and (rank <= _num_particles); ++rank) {
+            MPI_Recv(&rec_buffer,
+                    nmet,
+                    MPI_LONG_DOUBLE,
+                    MPI_ANY_SOURCE,
+                    MPI_ANY_TAG,
+                    _mp->comm,
+                    &status);
+            for (int m = 0; m<nmet; ++m) rec_data[status.MPI_TAG*nmet + m] = rec_buffer[m];
+        }
+
+        // Tell all the workers they're done for now
+        for (int rank = 1; rank < _mp->mpi_size; ++rank) {
+            MPI_Send(0, 0, MPI_INT, rank, STOP_TAG, _mp->comm);
+        }
+
+        vector<int> bad_particle_idx; // bandaid, in case simulator returns nonsense values
+        for (size_t i = 0; i < _num_particles; i++) {
+            for (size_t j = 0; j < nmet; j++) {
+                const double met_val = rec_data[i*nmet + j];
+                if (not isfinite(met_val)) bad_particle_idx.push_back(i);
+                X_orig(i, j) = rec_data[i*nmet + j];
+            }
+        }
+
+        // bandaid, in case simulator returns nonsense values
+        for (size_t i = 0; i < bad_particle_idx.size(); i++) {
+            X_orig.row(i).fill(numeric_limits<float_type>::min());
+            Y_orig.row(i).fill(numeric_limits<float_type>::min());
+        }
+
+        delete[] send_data;
+        delete[] rec_data;
+#endif
+    };
+
+    void particle_worker(
+        const size_t npar, const size_t nmet,
+        AbcSimFun* simulator,
+        const unsigned long int seed,
+        const unsigned long int serial,
+        MPI_par *_mp
+    ) {
+#ifdef USING_MPI
+        MPI_Status status;
+        auto *local_Y_data = new long double[npar]();
+        auto *local_X_data = new long double[nmet]();
+
+        while (1) {
+            MPI_Recv(local_Y_data, npar,
+                    MPI_LONG_DOUBLE,
+                    mpi_root,
+                    MPI_ANY_TAG,
+                    _mp->comm,
+                    &status);
+
+            // Check the tag of the received message.
+            if (status.MPI_TAG == STOP_TAG) {
+                delete[] local_Y_data;
+                delete[] local_X_data;
+                return;
+            }
+
+            Row pars(npar);
+            Row mets(nmet);
+
+            for (size_t j = 0; j < npar; j++) { pars[j] = local_Y_data[j]; }
+
+            mets = simulator(pars, seed, serial, _mp);
+    //        if (not success) exit(-210); // TODO handle throws / errors?
+
+            for (size_t j = 0; j < nmet; j++) { local_X_data[j] = mets[j]; }
+
+            MPI_Send(local_X_data, nmet,
+                    MPI_LONG_DOUBLE,
+                    mpi_root,
+                    status.MPI_TAG,
+                    _mp->comm);
+        }
+#endif
+    };
+
+}

--- a/AbcMPI.h
+++ b/AbcMPI.h
@@ -1,0 +1,28 @@
+
+#ifndef ABC_MPI_H
+#define ABC_MPI_H
+
+#include "pls.h" // for data types
+#include "AbcSim.h" // for AbcSimFun type
+#include "AbcMPIPar.h" // for the MPI_par struct
+
+// add MPI management to the ABC namespace
+namespace ABC {
+
+    void particle_scheduler(
+        Mat2D &X_orig, // metrics - should be properly sized in advance, to be filled in by this function
+        const Mat2D &Y_orig, // parameters - should be filled in advance (e.g. by sample_priors)
+        MPI_par *_mp
+    );
+
+    void particle_worker(
+        const size_t npar, const size_t nmet,
+        AbcSimFun* fptr,
+        const unsigned long int seed,
+        const unsigned long int serial,
+        MPI_par *_mp
+    );
+
+}
+
+#endif // ABC_MPI_H

--- a/AbcMPIPar.h
+++ b/AbcMPIPar.h
@@ -1,4 +1,5 @@
 
+// forward definition required because AbcSmc <=> AbcMPI cyclic dependency
 #ifndef ABC_MPI_PAR_H
 #define ABC_MPI_PAR_H
 

--- a/AbcMPIPar.h
+++ b/AbcMPIPar.h
@@ -1,0 +1,25 @@
+
+#ifndef ABC_MPI_PAR_H
+#define ABC_MPI_PAR_H
+
+#ifdef USING_MPI
+#include <mpi.h>
+#endif // USING_MPI
+
+// add MPI management to the ABC namespace
+namespace ABC {
+    
+    struct MPI_par {
+#ifdef USING_MPI
+        MPI_Comm comm;
+        MPI_Info info;
+        int mpi_size, mpi_rank;
+#else
+        const static int mpi_size = 1;
+        const static int mpi_rank = 0;
+#endif // USING_MPI
+    };
+
+}
+
+#endif // ABC_MPI_PAR_H

--- a/AbcSim.h
+++ b/AbcSim.h
@@ -4,6 +4,11 @@
 #include <vector> // container for receiving parameters / returning metrics
 #include <dlfcn.h> // for dynamic version
 #include <fstream> // for external executable version
+#include <sstream> // for stringstream
+#include <string> // for string
+
+#include "pls.h" // for float_type
+#include "AbcMPIPar.h"
 
 using std::vector;
 
@@ -11,19 +16,6 @@ using std::vector;
 // this must be defined in a matching way between and AbcSmc executables *and*
 // other code using this header.
 namespace ABC {
-  #ifdef USING_MPI
-  #include <mpi.h>
-  struct MPI_par {
-      MPI_Comm comm;
-      MPI_Info info;
-      int mpi_size, mpi_rank;
-  };
-  #else
-  struct MPI_par {
-      const static int mpi_size = 1;
-      const static int mpi_rank = 0;
-  };
-  #endif
 
   template <typename T>
   inline std::string toString (const T& t) {
@@ -95,8 +87,8 @@ struct AbcFPtr : AbcSimFun {
 // which should receive the parameters as a sequence of command line arguments and reply on standard out with the metrics
 // as a series of numbers.
 struct AbcExec : AbcSimFun {
-    const string command;
-    AbcExec(string _command) : command(_command) { }
+    const std::string command;
+    AbcExec(std::string _command) : command(_command) { }
 
     vector<float_type> operator()(
       vector<float_type> pars, const unsigned long int seed, const unsigned long int serial, const ABC::MPI_par* _mp
@@ -121,7 +113,7 @@ struct AbcExec : AbcSimFun {
         if (retval == "ERROR" or retval == "") {
             std::cerr << command << " does not exist or appears to be an invalid simulator on MPI rank " << _mp->mpi_rank << std::endl;
         } else {
-            stringstream ss;
+            std::stringstream ss;
             ss.str(retval);
             // TODO deal with empty mets on !particle_success
             float_type met;

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -596,11 +596,7 @@ bool AbcSmc::read_SMC_sets_from_database (sqdb::Db &db, vector< vector<int> > &s
 }*/
 
 
-<<<<<<< HEAD
 void AbcSmc::_particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
-=======
-void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
->>>>>>> 25e0c9c (encapsulate MPI support to clean up AbcSmc.cpp)
 
     auto _num_particles = get_num_particles(t);
 
@@ -623,11 +619,7 @@ void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, c
 }
 
 
-<<<<<<< HEAD
 void AbcSmc::_particle_worker_mpi(
-=======
-void AbcSmc::_particle_worker(
->>>>>>> 25e0c9c (encapsulate MPI support to clean up AbcSmc.cpp)
     const size_t seed,
     const size_t serial
 ) {

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -596,7 +596,7 @@ bool AbcSmc::read_SMC_sets_from_database (sqdb::Db &db, vector< vector<int> > &s
 }*/
 
 
-void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
+void AbcSmc::_particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
 
     auto _num_particles = get_num_particles(t);
 
@@ -619,7 +619,7 @@ void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, c
 }
 
 
-void AbcSmc::_particle_worker(
+void AbcSmc::_particle_worker_mpi(
     const size_t seed,
     const size_t serial
 ) {

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -596,7 +596,11 @@ bool AbcSmc::read_SMC_sets_from_database (sqdb::Db &db, vector< vector<int> > &s
 }*/
 
 
+<<<<<<< HEAD
 void AbcSmc::_particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
+=======
+void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
+>>>>>>> 25e0c9c (encapsulate MPI support to clean up AbcSmc.cpp)
 
     auto _num_particles = get_num_particles(t);
 
@@ -619,7 +623,11 @@ void AbcSmc::_particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_ori
 }
 
 
+<<<<<<< HEAD
 void AbcSmc::_particle_worker_mpi(
+=======
+void AbcSmc::_particle_worker(
+>>>>>>> 25e0c9c (encapsulate MPI support to clean up AbcSmc.cpp)
     const size_t seed,
     const size_t serial
 ) {

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -10,6 +10,7 @@
 #include "pls.h"
 #include "RunningStat.h"
 #include "AbcSmc.h"
+#include "AbcMPI.h"
 
 // need a positive int that is very unlikely
 // to be less than the number of particles
@@ -595,138 +596,34 @@ bool AbcSmc::read_SMC_sets_from_database (sqdb::Db &db, vector< vector<int> > &s
 }*/
 
 
-void AbcSmc::_particle_scheduler(int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
-#ifdef USING_MPI
-    MPI_Status status;
-    long double *send_data = new long double[npar() * _num_particles](); // all params, flattened array
-    long double *rec_data  = new long double[nmet() * _num_particles](); // all metrics, flattened array
+void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
+
+    auto _num_particles = get_num_particles(t);
 
     // sample parameter distributions; copy values into Y matrix and into send_data buffer
     Row par_row;
-    for (size_t i = 0; i<_num_particles; i++) {
-        if (t == 0) { // sample priors
-            par_row = sample_priors(RNG);
-            if (i < _num_particles) Y_orig.row(i) = par_row;
-        } else {      // sample predictive priors
-            par_row = sample_predictive_priors(t, RNG);
-            if (i < _num_particles) Y_orig.row(i) = par_row;
-        }
-        for (size_t j = 0; j < npar(); j++) { send_data[i*npar() + j] = par_row(j); }
-    }
-    // Seed the workers with the first 'num_workers' jobs
-    int particle_id = 0;
-    // Don't send particles that don't exist!
-    for (int rank = 1; rank < _mp->mpi_size and rank <= _num_particles; ++rank) {
-        particle_id = rank - 1;                       // which row in Y
-        MPI_Send(&send_data[particle_id*npar()],  // message buffer
-                 npar(),                          // number of elements
-                 MPI_LONG_DOUBLE,                 // data item is a double
-                 rank,                            // destination process rank
-                 particle_id,                     // message tag
-                 _mp->comm);                      // always use this
-    }
-
-    // Receive a result from any worker and dispatch a new work request
-    long double rec_buffer[nmet()];
-    particle_id++; // move cursor to next particle to be sent
-    while ( particle_id < _num_particles ) {
-        MPI_Recv(&rec_buffer,                     // message buffer
-                 nmet(),                          // message size
-                 MPI_LONG_DOUBLE,                 // of type double
-                 MPI_ANY_SOURCE,                  // receive from any sender
-                 MPI_ANY_TAG,                     // any type of message
-                 _mp->comm,                       // always use this
-                 &status);                        // received message info
-        for (int m = 0; m<nmet(); ++m) rec_data[status.MPI_TAG*nmet() + m] = rec_buffer[m];
-
-        MPI_Send(&send_data[particle_id*npar()],  // message buffer
-                 npar(),                          // number of elements
-                 MPI_LONG_DOUBLE,                 // data item is a double
-                 status.MPI_SOURCE,               // send it to the rank that just finished
-                 particle_id,                     // message tag
-                 _mp->comm);                      // always use this
-        particle_id++; // move cursor
-    }
-
-    // receive results for outstanding work requests--there are exactly 'num_workers'
-    // or '_num_particles' left, whichever is smaller
-    for (int rank = 1; rank < _mp->mpi_size and rank <= _num_particles; ++rank) {
-        MPI_Recv(&rec_buffer,
-                 nmet(),
-                 MPI_LONG_DOUBLE,
-                 MPI_ANY_SOURCE,
-                 MPI_ANY_TAG,
-                 _mp->comm,
-                 &status);
-        for (int m = 0; m<nmet(); ++m) rec_data[status.MPI_TAG*nmet() + m] = rec_buffer[m];
-    }
-
-    // Tell all the workers they're done for now
-    for (int rank = 1; rank < _mp->mpi_size; ++rank) {
-        MPI_Send(0, 0, MPI_INT, rank, STOP_TAG, _mp->comm);
-    }
-
-    vector<int> bad_particle_idx; // bandaid, in case simulator returns nonsense values
     for (size_t i = 0; i < _num_particles; i++) {
-        for (size_t j = 0; j < nmet(); j++) {
-            const double met_val = rec_data[i*nmet() + j];
-            if (not isfinite(met_val)) bad_particle_idx.push_back(i);
-            X_orig(i,j) = rec_data[i*nmet() + j];
+        if (t == 0) { // sample priors
+            Mat2D posterior = slurp_posterior();
+            int posterior_rank = -1;
+            Y_orig.row(i) = sample_priors(RNG, posterior, posterior_rank);
+        } else {      // sample predictive priors
+            Y_orig.row(i) = sample_predictive_priors(t, RNG);
         }
     }
 
-    // bandaid, in case simulator returns nonsense values
-    for (size_t i = 0; i < bad_particle_idx.size(); i++) {
-        X_orig.row(i).fill(numeric_limits<float_type>::min());
-        Y_orig.row(i).fill(numeric_limits<float_type>::min());
-    }
+    X_orig.resize(_num_particles, nmet());
 
-    delete[] send_data;
-    delete[] rec_data;
-#endif
+    ABC::particle_scheduler(X_orig, Y_orig, _mp);
+
 }
 
 
-void AbcSmc::_particle_worker() {
-#ifdef USING_MPI
-    MPI_Status status;
-    long double *local_Y_data = new long double[npar()]();
-    long double *local_X_data = new long double[nmet()]();
-
-    while (1) {
-        MPI_Recv(local_Y_data,
-                 npar(),
-                 MPI_LONG_DOUBLE,
-                 mpi_root,
-                 MPI_ANY_TAG,
-                 _mp->comm,
-                 &status);
-
-        // Check the tag of the received message.
-        if (status.MPI_TAG == STOP_TAG) {
-            delete[] local_Y_data;
-            delete[] local_X_data;
-            return;
-        }
-
-        Row pars(npar());
-        Row mets(nmet());
-
-        for (size_t j = 0; j < npar(); j++) { pars[j] = local_Y_data[j]; }
-
-        bool success = _run_simulator(pars, mets);
-        if (not success) exit(-210);
-
-        for (size_t j = 0; j < nmet(); j++) { local_X_data[j] = mets[j]; }
-
-        MPI_Send(local_X_data,
-                 nmet(),
-                 MPI_LONG_DOUBLE,
-                 mpi_root,
-                 status.MPI_TAG,
-                 _mp->comm);
-    }
-#endif
+void AbcSmc::_particle_worker(
+    const size_t seed,
+    const size_t serial
+) {
+    ABC::particle_worker(npar(), nmet(), _simulator, seed, serial, _mp);
 }
 
 

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -215,7 +215,7 @@ class AbcSmc {
         size_t get_smc_iterations() { return _num_smc_sets; }
         //void set_smc_set_sizes(vector<int> n) { _smc_set_sizes = n; }
 
-        size_t get_num_particles(size_t set_num, VerboseType vt = VERBOSE) {
+        size_t get_num_particles(const size_t set_num, const VerboseType vt = VERBOSE) {
             int set_size = 0;
             if (set_num < _smc_set_sizes.size()) {
                 set_size = _smc_set_sizes[set_num];
@@ -357,9 +357,10 @@ class AbcSmc {
 
         bool _populate_particles( int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG );
 
-        bool _populate_particles_mpi( int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG );
-        void _particle_scheduler(int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
-        void _particle_worker();
+//      TODO: undefined?
+//        bool _populate_particles_mpi( int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG );
+        void _particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
+        void _particle_worker(const size_t seed, const size_t serial);
 
         void _fp_helper(const int t, const Mat2D &X_orig, const Mat2D &Y_orig, const int next_pred_prior_size, const Col& distances);
         void _filter_particles_simple(int t, Mat2D &X_orig, Mat2D &Y_orig, int pred_prior_size);

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -359,8 +359,8 @@ class AbcSmc {
 
 //      TODO: undefined?
 //        bool _populate_particles_mpi( int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG );
-        void _particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
-        void _particle_worker(const size_t seed, const size_t serial);
+        void _particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
+        void _particle_worker_mpi(const size_t seed, const size_t serial);
 
         void _fp_helper(const int t, const Mat2D &X_orig, const Mat2D &Y_orig, const int next_pred_prior_size, const Col& distances);
         void _filter_particles_simple(int t, Mat2D &X_orig, Mat2D &Y_orig, int pred_prior_size);

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ endif
 #LIBS = -lm -L$(TACC_GSL_LIB/) -L$(HPC_GSL_LIB/) -lgsl -lgslcblas
 LIBS = -lm -lgsl -lgslcblas
 
-ABCSOURCES =  pls.cpp AbcUtil.cpp AbcSmc.cpp CCRC32.cpp
+ABCSOURCES =  pls.cpp AbcUtil.cpp AbcSmc.cpp CCRC32.cpp AbcMPI.cpp
 JSONSOURCES = $(patsubst %,$(JSONDIR)/src/%.cpp,json_reader json_value json_writer)
 SQLSOURCES  = $(addprefix $(SQLDIR)/,sqdb.cpp sqlite3.c)
 
 ABCOBJECTS  = $(ABCSOURCES:.cpp=.o)
 JSONOBJECTS = $(JSONSOURCES:.cpp=.o)
 SQLOBJECTS  = $(SQLDIR)/sqdb.o $(SQLDIR)/sqlite3.o
-ABC_HEADER = ./pls.h ./AbcUtil.h ./AbcSmc.h ./AbcSim.h
+ABC_HEADER = ./pls.h ./AbcUtil.h ./AbcSmc.h ./AbcSim.h ./AbcMPI.h ./AbcMPIPar.h
 
 default: libabc.a
 


### PR DESCRIPTION
This moves the MPI support into it's own h/cpp. I think longer term, this might want to be an option for AbcSim functors - i.e. push the management of the MPI elements into the simulation wrapper.

That might entail changing the simulator invocation to support "call n of these"? Not sure.