### PR TITLE
shifting functionality towards AbcUtil

### DIFF
--- a/AbcLog.cpp
+++ b/AbcLog.cpp
@@ -31,27 +31,13 @@ void AbcLog::report_convergence_data(
              << "       This can happen if --process is called on a database that is not ready to be processed." << std::endl;
         exit(-214);
     }
-    vector<double> last_means( abc->npar(), 0 );
-    vector<double> current_means = last_means; // copy contructor
-    for (size_t j = 0; j < current_means.size(); j++) {
-    //cerr << "par " << j << endl;
-        size_t N = abc->_predictive_prior[set_t].size();
-        for (size_t i = 0; i < N; i++) {
-            int particle_idx = abc->_predictive_prior[set_t][i];
-            double par_value = abc->_particle_parameters[set_t](particle_idx, j);
-            current_means[j] += par_value;
-        }
-        current_means[j] /= N;
 
-        if (set_t > 0) {
-            const size_t N2 = abc->_predictive_prior[set_t-1].size();
-            for (size_t i = 0; i < N2; i++) {
-                int particle_idx = abc->_predictive_prior[set_t-1][i];
-                double par_value = abc->_particle_parameters[set_t-1](particle_idx, j);
-                last_means[j] += par_value;
-            }
-            last_means[j] /= N2;
-        }
+    Mat2D pars = abc->_particle_parameters[set_t](abc->_predictive_prior[set_t], Eigen::placeholders::all);
+    Row current_means = pars.colwise().mean();
+    Row last_means;
+    if (set_t > 0) {
+        pars = abc->_particle_parameters[set_t-1](abc->_predictive_prior[set_t-1], Eigen::placeholders::all);
+        last_means = pars.colwise().mean();
     }
 
     os << double_bar << std::endl;

--- a/AbcLog.cpp
+++ b/AbcLog.cpp
@@ -48,7 +48,7 @@ void AbcLog::report_convergence_data(
     }
     for (size_t i = 0; i < abc->_model_pars.size(); i++) {
         const Parameter* par = abc->_model_pars[i];
-        const double current_stdev = sqrt(par->get_doubled_variance(set_t)/2.0);
+        const double current_stdev = sqrt(abc->_doubled_variance[set_t][i]/2.0);
         const double prior_mean = par->get_prior_mean();
         const double prior_mean_delta = current_means[i] - prior_mean;
         const double prior_mean_pct_chg = prior_mean != 0 ? 100 * prior_mean_delta / prior_mean : INFINITY;
@@ -64,7 +64,7 @@ void AbcLog::report_convergence_data(
             os << "  Standard deviations:\n";
             print_stats("Prior", "current", prior_stdev, current_stdev, prior_stdev_delta, prior_stdev_pct_chg, "\n", os);
         } else {
-            double last_stdev = sqrt(abc->_model_pars[i]->get_doubled_variance(set_t-1)/2.0);
+            double last_stdev = sqrt(abc->_doubled_variance[set_t-1][i]/2.0);
             double delta, pct_chg;
 
             os << "  Par " << i << ": \"" << abc->_model_pars[i]->get_name() << "\"" << std::endl;

--- a/AbcLog.cpp
+++ b/AbcLog.cpp
@@ -1,0 +1,144 @@
+#include "AbcLog.h"
+
+// TODO: longer term goal is to have these *not* have an AbcSmc argument
+// and instead have the specific elements they need passed in as arguments
+
+void AbcLog::print_stats(
+    const std::string & str1, const std::string & str2,
+    const double val1, const double val2, const double delta, const double pct_chg,
+    const std::string & tail, ostream& os
+) {
+    os << "    " + str1 + ", " + str2 + "  ( delta, % ): "  << setw(WIDTH) << val1 << ", " << setw(WIDTH) << val2
+                                                      << " ( " << setw(WIDTH) << delta << ", " << setw(WIDTH) << pct_chg  << "% )\n" + tail;
+}
+
+
+void AbcLog::_print_particle_table_header(
+    AbcSmc * abc,
+    std::ostream & os
+) {
+    for (size_t i = 0; i < abc->npar(); i++) { os << setw(WIDTH) << abc->_model_pars[i]->get_short_name(); } os << " | ";
+    for (size_t i = 0; i < abc->nmet(); i++) { os << setw(WIDTH) << abc->_model_mets[i]->get_short_name(); } os << std::endl;
+}
+
+void AbcLog::report_convergence_data(
+    AbcSmc *abc,
+    const size_t set_t,
+    std::ostream & os
+) {
+    if( abc->_predictive_prior.size() <= set_t ) {
+        os << "ERROR: attempting to report stats for set " << set_t << ", but data aren't available. " << std::endl
+             << "       This can happen if --process is called on a database that is not ready to be processed." << std::endl;
+        exit(-214);
+    }
+    vector<double> last_means( abc->npar(), 0 );
+    vector<double> current_means = last_means; // copy contructor
+    for (size_t j = 0; j < current_means.size(); j++) {
+    //cerr << "par " << j << endl;
+        size_t N = abc->_predictive_prior[set_t].size();
+        for (size_t i = 0; i < N; i++) {
+            int particle_idx = abc->_predictive_prior[set_t][i];
+            double par_value = abc->_particle_parameters[set_t](particle_idx, j);
+            current_means[j] += par_value;
+        }
+        current_means[j] /= N;
+
+        if (set_t > 0) {
+            const size_t N2 = abc->_predictive_prior[set_t-1].size();
+            for (size_t i = 0; i < N2; i++) {
+                int particle_idx = abc->_predictive_prior[set_t-1][i];
+                double par_value = abc->_particle_parameters[set_t-1](particle_idx, j);
+                last_means[j] += par_value;
+            }
+            last_means[j] /= N2;
+        }
+    }
+
+    os << double_bar << std::endl;
+    if (set_t == 0) {
+        os << "Predictive prior summary statistics:\n";
+    } else {
+        os << "Convergence data for predictive priors:\n";
+    }
+    for (size_t i = 0; i < abc->_model_pars.size(); i++) {
+        const Parameter* par = abc->_model_pars[i];
+        const double current_stdev = sqrt(par->get_doubled_variance(set_t)/2.0);
+        const double prior_mean = par->get_prior_mean();
+        const double prior_mean_delta = current_means[i] - prior_mean;
+        const double prior_mean_pct_chg = prior_mean != 0 ? 100 * prior_mean_delta / prior_mean : INFINITY;
+
+        const double prior_stdev = par->get_prior_stdev();
+        const double prior_stdev_delta = current_stdev - prior_stdev;
+        const double prior_stdev_pct_chg = prior_stdev != 0 ? 100 * prior_stdev_delta / prior_stdev : INFINITY;
+        if (set_t == 0) {
+            os << "  Par " << i << ": \"" << par->get_name() << "\"\n";
+
+            os << "  Means:\n";
+            print_stats("Prior", "current", prior_mean, current_means[i], prior_mean_delta, prior_mean_pct_chg, "", os);
+            os << "  Standard deviations:\n";
+            print_stats("Prior", "current", prior_stdev, current_stdev, prior_stdev_delta, prior_stdev_pct_chg, "\n", os);
+        } else {
+            double last_stdev = sqrt(abc->_model_pars[i]->get_doubled_variance(set_t-1)/2.0);
+            double delta, pct_chg;
+
+            os << "  Par " << i << ": \"" << abc->_model_pars[i]->get_name() << "\"" << std::endl;
+
+            delta = current_means[i] - last_means[i];
+            pct_chg = last_means[i] != 0 ? 100 * delta / last_means[i] : INFINITY;
+            os << "  Means:" << std::endl;
+            print_stats("Prior", "current", prior_mean, current_means[i], prior_mean_delta, prior_mean_pct_chg, "", os);
+            print_stats("Last", " current", last_means[i], current_means[i], delta, pct_chg, "\n", os);
+
+            delta = current_stdev - last_stdev;
+            pct_chg = last_stdev != 0 ? 100 * delta / last_stdev : INFINITY;
+            os << "  Standard deviations:\n";
+            print_stats("Prior", "current", prior_stdev, current_stdev, prior_stdev_delta, prior_stdev_pct_chg, "", os);
+            print_stats("Last", " current", last_stdev, current_stdev, delta, pct_chg, "\n", os);
+        }
+    }
+}
+
+void AbcLog::filtering_report(
+    AbcSmc * abc,
+    const size_t t,
+    const Mat2D & posterior_pars, // rows = samples, by rank; cols = parameters, by order
+    const Mat2D & posterior_mets, // rows = samples, by rank; cols = metrics, by order
+    std::ostream & os
+) {
+    os << double_bar << std::endl << "Set " << t << std::endl << double_bar << std::endl;
+
+    os << "Observed:" << std::endl;
+    AbcLog::_print_particle_table_header(abc, os);
+    for (size_t i = 0; i < posterior_pars.cols(); i++) { os << setw(WIDTH) << "---"; } os << " | ";
+    for (auto modmet : abc->_model_mets) { os << setw(WIDTH) << modmet->get_obs_val(); } os << std::endl;
+
+    os << "Normalized RMSE for metric means (lower is better):  " << ABC::calculate_nrmse(posterior_mets, abc->_met_vals) << std::endl;
+    os << "Posterior means:" << std::endl;
+    AbcLog::_print_particle_table_header(abc, os);
+    for (auto meanpar : posterior_pars.colwise().mean()) { os << setw(WIDTH) << meanpar; } os << " | ";
+    for (auto meanmet : posterior_mets.colwise().mean()) { os << setw(WIDTH) << meanmet; } os << std::endl;
+
+    os << "Posterior medians:" << std::endl;
+    AbcLog::_print_particle_table_header(abc, os);
+    for (auto parcol : posterior_pars.colwise()) { os << setw(WIDTH) << ABC::median(parcol); } os << " | ";
+    for (auto metcol : posterior_mets.colwise()) { os << setw(WIDTH) << ABC::median(metcol); } os << std::endl;
+
+    os << "Best five:" << std::endl;
+    AbcLog::_print_particle_table_header(abc, os);
+    auto partop = posterior_pars.topRows(5);
+    auto mettop = posterior_mets.topRows(5);
+    for (size_t q = 0; q < 5; q++) {
+        for (auto par : partop.row(q)) { os << setw(WIDTH) << par; } os << " | ";
+        for (auto met : mettop.row(q)) { os << setw(WIDTH) << met; } os << std::endl;
+    }
+
+    os << "Worst five:" << std::endl;
+    AbcLog::_print_particle_table_header(abc, os);
+    auto parbot = posterior_pars.bottomRows(5);
+    auto metbot = posterior_mets.bottomRows(5);
+    for (size_t q = 0; q < 5; q++) {
+        for (auto par : parbot.row(q)) { os << setw(WIDTH) << par; } os << " | ";
+        for (auto met : metbot.row(q)) { os << setw(WIDTH) << met; } os << std::endl;
+    }
+
+}

--- a/AbcLog.h
+++ b/AbcLog.h
@@ -1,0 +1,45 @@
+
+#ifndef ABC_LOG_H
+#define ABC_LOG_H
+
+#include <iostream>
+
+#include "AbcSmc.h"
+
+struct AbcLog {
+
+    static void report_convergence_data(
+        AbcSmc * abc, const size_t t,
+        std::ostream & os = std::cerr
+    );
+    static void _print_particle_table_header(
+        AbcSmc * abc,
+        std::ostream & os = std::cerr
+    );
+
+    static void print_stats(
+        const std::string & str1, const std::string & str2,
+        const double val1, const double val2,
+        const double delta, const double pct_chg,
+        const string & tail,
+        ostream& os = std::cerr
+    );
+
+    static void filtering_report(
+        AbcSmc * abc,
+        const size_t t,
+        const Mat2D & posterior_pars, // rows = samples, by rank; cols = parameters, by order
+        const Mat2D & posterior_mets, // rows = samples, by rank; cols = metrics, by order
+        std::ostream & os = std::cerr
+    );
+
+
+    inline static const int WIDTH = 12;
+    inline static const string double_bar = "=========================================================================================";
+
+    private:
+        AbcLog() {};
+
+};
+
+#endif

--- a/AbcMPI.cpp
+++ b/AbcMPI.cpp
@@ -1,0 +1,147 @@
+
+#include "AbcMPI.h" // pre declarations for MPI functions / types
+
+// TODO is there a way to capture this approach in AbcSim?
+// As with those functors, this is largely a wrapper around a function pointer
+
+namespace ABC {
+    void particle_scheduler(
+        Mat2D &X_orig, // metrics - should be properly sized in advance, to be filled in by this function
+        const Mat2D &Y_orig, // parameters - should be filled in advance (e.g. by sample_priors)
+        MPI_par *_mp
+    ) {
+#ifdef USING_MPI
+        MPI_Status status;
+        assert(X_orig.rows() == Y_orig.rows());
+
+        auto *send_data = new long double[Y_orig.size()](); // all params, flattened array
+        auto *rec_data  = new long double[X_orig.size()](); // all metrics, flattened array
+
+        const size_t _num_particles = Y_orig.rows();
+        const size_t npar = Y_orig.cols();
+        const size_t nmet = X_orig.cols();
+
+        // sample parameter distributions; copy values into Y matrix and into send_data buffer
+        for (size_t i = 0; i < _num_particles; i++) {
+            for (size_t j = 0; j < npar; j++) { send_data[i*npar + j] = Y_orig(i, j); }
+        }
+        // Seed the workers with the first 'num_workers' jobs
+        int particle_id = 0;
+        // Don't send particles that don't exist!
+        for (int rank = 1; (rank < _mp->mpi_size) and (rank <= _num_particles); ++rank) {
+            particle_id = rank - 1;                       // which row in Y
+            MPI_Send(&send_data[particle_id*npar],  // message buffer
+                    npar,                          // number of elements
+                    MPI_LONG_DOUBLE,                 // data item is a double
+                    rank,                            // destination process rank
+                    particle_id,                     // message tag
+                    _mp->comm);                      // always use this
+        }
+
+        // Receive a result from any worker and dispatch a new work request
+        long double rec_buffer[nmet];
+        particle_id++; // move cursor to next particle to be sent
+        while ( particle_id < _num_particles ) {
+            MPI_Recv(&rec_buffer,                     // message buffer
+                    nmet,                          // message size
+                    MPI_LONG_DOUBLE,                 // of type double
+                    MPI_ANY_SOURCE,                  // receive from any sender
+                    MPI_ANY_TAG,                     // any type of message
+                    _mp->comm,                       // always use this
+                    &status);                        // received message info
+            for (int m = 0; m<nmet; ++m) rec_data[status.MPI_TAG*nmet + m] = rec_buffer[m];
+
+            MPI_Send(&send_data[particle_id*npar],  // message buffer
+                    npar,                          // number of elements
+                    MPI_LONG_DOUBLE,                 // data item is a double
+                    status.MPI_SOURCE,               // send it to the rank that just finished
+                    particle_id,                     // message tag
+                    _mp->comm);                      // always use this
+            particle_id++; // move cursor
+        }
+
+        // receive results for outstanding work requests--there are exactly 'num_workers'
+        // or '_num_particles' left, whichever is smaller
+        for (int rank = 1; (rank < _mp->mpi_size) and (rank <= _num_particles); ++rank) {
+            MPI_Recv(&rec_buffer,
+                    nmet,
+                    MPI_LONG_DOUBLE,
+                    MPI_ANY_SOURCE,
+                    MPI_ANY_TAG,
+                    _mp->comm,
+                    &status);
+            for (int m = 0; m<nmet; ++m) rec_data[status.MPI_TAG*nmet + m] = rec_buffer[m];
+        }
+
+        // Tell all the workers they're done for now
+        for (int rank = 1; rank < _mp->mpi_size; ++rank) {
+            MPI_Send(0, 0, MPI_INT, rank, STOP_TAG, _mp->comm);
+        }
+
+        vector<int> bad_particle_idx; // bandaid, in case simulator returns nonsense values
+        for (size_t i = 0; i < _num_particles; i++) {
+            for (size_t j = 0; j < nmet; j++) {
+                const double met_val = rec_data[i*nmet + j];
+                if (not isfinite(met_val)) bad_particle_idx.push_back(i);
+                X_orig(i, j) = rec_data[i*nmet + j];
+            }
+        }
+
+        // bandaid, in case simulator returns nonsense values
+        for (size_t i = 0; i < bad_particle_idx.size(); i++) {
+            X_orig.row(i).fill(numeric_limits<float_type>::min());
+            Y_orig.row(i).fill(numeric_limits<float_type>::min());
+        }
+
+        delete[] send_data;
+        delete[] rec_data;
+#endif
+    };
+
+    void particle_worker(
+        const size_t npar, const size_t nmet,
+        AbcSimFun* simulator,
+        const unsigned long int seed,
+        const unsigned long int serial,
+        MPI_par *_mp
+    ) {
+#ifdef USING_MPI
+        MPI_Status status;
+        auto *local_Y_data = new long double[npar]();
+        auto *local_X_data = new long double[nmet]();
+
+        while (1) {
+            MPI_Recv(local_Y_data, npar,
+                    MPI_LONG_DOUBLE,
+                    mpi_root,
+                    MPI_ANY_TAG,
+                    _mp->comm,
+                    &status);
+
+            // Check the tag of the received message.
+            if (status.MPI_TAG == STOP_TAG) {
+                delete[] local_Y_data;
+                delete[] local_X_data;
+                return;
+            }
+
+            Row pars(npar);
+            Row mets(nmet);
+
+            for (size_t j = 0; j < npar; j++) { pars[j] = local_Y_data[j]; }
+
+            mets = simulator(pars, seed, serial, _mp);
+    //        if (not success) exit(-210); // TODO handle throws / errors?
+
+            for (size_t j = 0; j < nmet; j++) { local_X_data[j] = mets[j]; }
+
+            MPI_Send(local_X_data, nmet,
+                    MPI_LONG_DOUBLE,
+                    mpi_root,
+                    status.MPI_TAG,
+                    _mp->comm);
+        }
+#endif
+    };
+
+}

--- a/AbcMPI.h
+++ b/AbcMPI.h
@@ -1,0 +1,28 @@
+
+#ifndef ABC_MPI_H
+#define ABC_MPI_H
+
+#include "pls.h" // for data types
+#include "AbcSim.h" // for AbcSimFun type
+#include "AbcMPIPar.h" // for the MPI_par struct
+
+// add MPI management to the ABC namespace
+namespace ABC {
+
+    void particle_scheduler(
+        Mat2D &X_orig, // metrics - should be properly sized in advance, to be filled in by this function
+        const Mat2D &Y_orig, // parameters - should be filled in advance (e.g. by sample_priors)
+        MPI_par *_mp
+    );
+
+    void particle_worker(
+        const size_t npar, const size_t nmet,
+        AbcSimFun* fptr,
+        const unsigned long int seed,
+        const unsigned long int serial,
+        MPI_par *_mp
+    );
+
+}
+
+#endif // ABC_MPI_H

--- a/AbcMPIPar.h
+++ b/AbcMPIPar.h
@@ -1,4 +1,5 @@
 
+// forward definition required because AbcSmc <=> AbcMPI cyclic dependency
 #ifndef ABC_MPI_PAR_H
 #define ABC_MPI_PAR_H
 

--- a/AbcMPIPar.h
+++ b/AbcMPIPar.h
@@ -1,0 +1,25 @@
+
+#ifndef ABC_MPI_PAR_H
+#define ABC_MPI_PAR_H
+
+#ifdef USING_MPI
+#include <mpi.h>
+#endif // USING_MPI
+
+// add MPI management to the ABC namespace
+namespace ABC {
+    
+    struct MPI_par {
+#ifdef USING_MPI
+        MPI_Comm comm;
+        MPI_Info info;
+        int mpi_size, mpi_rank;
+#else
+        const static int mpi_size = 1;
+        const static int mpi_rank = 0;
+#endif // USING_MPI
+    };
+
+}
+
+#endif // ABC_MPI_PAR_H

--- a/AbcSim.h
+++ b/AbcSim.h
@@ -4,6 +4,11 @@
 #include <vector> // container for receiving parameters / returning metrics
 #include <dlfcn.h> // for dynamic version
 #include <fstream> // for external executable version
+#include <sstream> // for stringstream
+#include <string> // for string
+
+#include "pls.h" // for float_type
+#include "AbcMPIPar.h"
 
 using std::vector;
 
@@ -11,19 +16,6 @@ using std::vector;
 // this must be defined in a matching way between and AbcSmc executables *and*
 // other code using this header.
 namespace ABC {
-  #ifdef USING_MPI
-  #include <mpi.h>
-  struct MPI_par {
-      MPI_Comm comm;
-      MPI_Info info;
-      int mpi_size, mpi_rank;
-  };
-  #else
-  struct MPI_par {
-      const static int mpi_size = 1;
-      const static int mpi_rank = 0;
-  };
-  #endif
 
   template <typename T>
   inline std::string toString (const T& t) {
@@ -95,8 +87,8 @@ struct AbcFPtr : AbcSimFun {
 // which should receive the parameters as a sequence of command line arguments and reply on standard out with the metrics
 // as a series of numbers.
 struct AbcExec : AbcSimFun {
-    const string command;
-    AbcExec(string _command) : command(_command) { }
+    const std::string command;
+    AbcExec(std::string _command) : command(_command) { }
 
     vector<float_type> operator()(
       vector<float_type> pars, const unsigned long int seed, const unsigned long int serial, const ABC::MPI_par* _mp
@@ -121,7 +113,7 @@ struct AbcExec : AbcSimFun {
         if (retval == "ERROR" or retval == "") {
             std::cerr << command << " does not exist or appears to be an invalid simulator on MPI rank " << _mp->mpi_rank << std::endl;
         } else {
-            stringstream ss;
+            std::stringstream ss;
             ss.str(retval);
             // TODO deal with empty mets on !particle_success
             float_type met;

--- a/AbcSim.h
+++ b/AbcSim.h
@@ -91,7 +91,7 @@ struct AbcExec : AbcSimFun {
     AbcExec(std::string _command) : command(_command) { }
 
     vector<float_type> operator()(
-      vector<float_type> pars, const unsigned long int seed, const unsigned long int serial, const ABC::MPI_par* _mp
+      vector<float_type> pars, const unsigned long int /*seed*/, const unsigned long int /*serial*/, const ABC::MPI_par* /*_mp*/
     ) const {
         auto execcom = command;
         vector<float_type> mets;

--- a/AbcSim.h
+++ b/AbcSim.h
@@ -41,7 +41,7 @@ struct AbcSimFun {
 // will be thrown when the simulator is used.
 struct AbcSimUnset : AbcSimFun {
     vector<float_type> operator()(
-      vector<float_type> pars, const unsigned long int seed, const unsigned long int serial, const ABC::MPI_par* _mp
+      vector<float_type> /*pars*/, const unsigned long int /*seed*/, const unsigned long int /*serial*/, const ABC::MPI_par* /*_mp*/
     ) const {
         std::cerr << "ERROR: A pointer to a simulator function (prefered) or an external simulator executable must be defined." << std::endl;
         exit(100);

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -952,14 +952,13 @@ PLS_Model AbcSmc::_filter_particles(
     size_t ncomp = npar();             // It doesn't make sense to consider more components than model parameters
 
     PLS_Model plsm(X.topRows(pls_training_set_size), Y.topRows(pls_training_set_size), ncomp);
-
-    // A is number of components to use
-    if (verbose) { plsm.print_explained_variance(X, Y); }
-
     const int test_set_size = X.rows() - pls_training_set_size; // number of observations not in training set
     auto num_components = plsm.optimal_num_components(X.bottomRows(test_set_size), Y.bottomRows(test_set_size), NEW_DATA);
+
     size_t num_components_used = num_components.maxCoeff();
     if (verbose) {
+        cerr << "Trained on: " << pls_training_set_size << " - Validation Set size: " << test_set_size << std::endl;
+        plsm.print_explained_variance(X, Y);
         cerr << "Optimal number of components for each parameter (validation method == NEW DATA):\t" << num_components << endl;
         cerr << "Using " << num_components_used << " components." << endl;
     }

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -508,7 +508,11 @@ bool AbcSmc::read_SMC_sets_from_database (sqdb::Db &db, vector< vector<int> > &s
 }*/
 
 
+<<<<<<< HEAD
 void AbcSmc::_particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
+=======
+void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
+>>>>>>> 25e0c9c (encapsulate MPI support to clean up AbcSmc.cpp)
 
     auto _num_particles = get_num_particles(t);
 
@@ -531,7 +535,11 @@ void AbcSmc::_particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_ori
 }
 
 
+<<<<<<< HEAD
 void AbcSmc::_particle_worker_mpi(
+=======
+void AbcSmc::_particle_worker(
+>>>>>>> 25e0c9c (encapsulate MPI support to clean up AbcSmc.cpp)
     const size_t seed,
     const size_t serial
 ) {

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -985,22 +985,11 @@ PLS_Model AbcSmc::_filter_particles (
     // Is casting as real always safe?
     Row   obs_scores = plsm.scores(obs_met, num_components_used).row(0).real();
     Mat2D sim_scores = plsm.scores(X, num_components_used).real();
-    Col   distances  = euclidean(obs_scores, sim_scores);
+    Col   distances  = ABC::euclidean(obs_scores, sim_scores);
 
     _set_predictive_prior(t, next_pred_prior_size, distances);
 
     return plsm;
-}
-
-Col AbcSmc::euclidean( Row obs_met, Mat2D sim_met ) {
-    Col distances = Col::Zero(sim_met.rows());
-    for (int r = 0; r<sim_met.rows(); r++) {
-        for (int c = 0; c<sim_met.cols(); c++) {
-            distances(r) += pow(obs_met(c) - sim_met(r,c), 2);
-        }
-        distances(r) = sqrt( distances(r) );
-    }
-    return distances;
 }
 
 Mat2D AbcSmc::slurp_posterior() {

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -1205,21 +1205,21 @@ gsl_matrix* AbcSmc::setup_mvn_sampler(const int set_num) {
 }
 
 
-Row AbcSmc::sample_mvn_predictive_priors( int set_num, const gsl_rng* RNG, gsl_matrix* L ) {
-    // SELECT PARTICLE FROM PRED PRIOR TO USE AS EXPECTED VALUE OF NEW SAMPLE
-    const Row par = sample_posterior(RNG,
-        _weights[set_num-1],
-        _particle_parameters[set_num-1](_predictive_prior[set_num-1], Eigen::placeholders::all)
+Row AbcSmc::sample_mvn_predictive_priors(
+    int set_num, const gsl_rng* RNG, gsl_matrix* L
+) {
+    return ABC::sample_mvn_predictive_priors(
+        RNG, _weights[set_num-1],
+        _particle_parameters[set_num-1](_predictive_prior[set_num-1], Eigen::placeholders::all),
+        _model_pars,
+        L
     );
-    gsl_vector* par_val_hat = to_gsl_v(par);
-    Row par_values = rand_trunc_mv_normal( _model_pars, par_val_hat, L, RNG );
-    gsl_vector_free(par_val_hat);
-
-    return par_values;
 }
 
-Row AbcSmc::sample_predictive_priors( int set_num, const gsl_rng* RNG ) {
-    ABC::sample_predictive_priors(
+Row AbcSmc::sample_predictive_priors(
+    int set_num, const gsl_rng* RNG
+) {
+    return ABC::sample_predictive_priors(
         RNG, _weights[set_num-1],
         _particle_parameters[set_num-1](_predictive_prior[set_num-1], Eigen::placeholders::all),
         _model_pars,

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -508,7 +508,7 @@ bool AbcSmc::read_SMC_sets_from_database (sqdb::Db &db, vector< vector<int> > &s
 }*/
 
 
-void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
+void AbcSmc::_particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
 
     auto _num_particles = get_num_particles(t);
 
@@ -531,7 +531,7 @@ void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, c
 }
 
 
-void AbcSmc::_particle_worker(
+void AbcSmc::_particle_worker_mpi(
     const size_t seed,
     const size_t serial
 ) {

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -508,11 +508,7 @@ bool AbcSmc::read_SMC_sets_from_database (sqdb::Db &db, vector< vector<int> > &s
 }*/
 
 
-<<<<<<< HEAD
 void AbcSmc::_particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
-=======
-void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
->>>>>>> 25e0c9c (encapsulate MPI support to clean up AbcSmc.cpp)
 
     auto _num_particles = get_num_particles(t);
 
@@ -535,11 +531,7 @@ void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, c
 }
 
 
-<<<<<<< HEAD
 void AbcSmc::_particle_worker_mpi(
-=======
-void AbcSmc::_particle_worker(
->>>>>>> 25e0c9c (encapsulate MPI support to clean up AbcSmc.cpp)
     const size_t seed,
     const size_t serial
 ) {

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -919,10 +919,12 @@ void AbcSmc::_set_predictive_prior (
 
 void AbcSmc::_filter_particles_simple (int t, Mat2D &X_orig, Mat2D &Y_orig, int next_pred_prior_size) {
     // x is metrics, y is parameters
-    Row X_sim_means, X_sim_stdev;
+    Row X_sim_means = X_orig.colwise().mean();
+    Row X_sim_stdev = ABC::colwise_stdev(X_orig, X_sim_means);
+    Row obs_met = z_scores(_met_vals, X_sim_means, X_sim_stdev);
+
     Mat2D X = colwise_z_scores( X_orig, X_sim_means, X_sim_stdev );
-    Mat2D Y = colwise_z_scores( Y_orig );
-    Row obs_met = _z_transform_observed_metrics( X_sim_means, X_sim_stdev );
+//    Mat2D Y = colwise_z_scores( Y_orig );
 
     Col distances  = euclidean(obs_met, X);
     _set_predictive_prior (t, next_pred_prior_size, distances);
@@ -956,10 +958,11 @@ PLS_Model AbcSmc::_filter_particles (
     int t, Mat2D &X_orig, Mat2D &Y_orig, int next_pred_prior_size,
     const bool verbose
 ) {
-    Row X_sim_means, X_sim_stdev;
+    Row X_sim_means = X_orig.colwise().mean();
+    Row X_sim_stdev = colwise_stdev(X_orig, X_sim_means);
     Mat2D X = colwise_z_scores( X_orig, X_sim_means, X_sim_stdev );
     Mat2D Y = colwise_z_scores( Y_orig );
-    Row obs_met = _z_transform_observed_metrics( X_sim_means, X_sim_stdev );
+    Row obs_met = z_scores(_met_vals, X_sim_means, X_sim_stdev);
 
     const size_t pls_training_set_size = round(X.rows() * _pls_training_fraction);
     // @tjh TODO -- I think this may be a bug, and that ncomp should be equal to number of predictor variables (metrics in this case), not reponse variables
@@ -1136,13 +1139,11 @@ void AbcSmc::calculate_predictive_prior_weights(int set_num) {
     calculate_doubled_variances( set_num );
     if (set_num == 0) {
         // uniform weights for set 0 predictive prior
-        //_weights[set_num].resize(_predictive_prior[set_num].size(), 1.0/(double) _predictive_prior[set_num].size());
         const double uniform_wt = 1.0/(double) _predictive_prior[set_num].size();
-        _weights.push_back( vector<double>(_predictive_prior[set_num].size(), uniform_wt) );
+        _weights.push_back( Col::Constant(_predictive_prior[set_num].size(), uniform_wt) );
     } else if ( set_num > 0 ) {
         // weights from set - 1 are needed to calculate weights for current set
-        _weights.push_back( vector<double>( _predictive_prior[set_num].size(), 0.0 ) );
-        //_weights[set_num].resize( _predictive_prior[set_num].size() );
+        Col weight = Col::Zero(_predictive_prior[set_num].size());
 
         Mat2D pars = _particle_parameters[set_num](_predictive_prior[set_num], Eigen::placeholders::all);
         Mat2D prev_pars = _particle_parameters[set_num-1](_predictive_prior[set_num-1], Eigen::placeholders::all);
@@ -1163,7 +1164,7 @@ void AbcSmc::calculate_predictive_prior_weights(int set_num) {
             }
 
             for (size_t k = 0; k < prev_pars.rows(); k++) {
-                double running_product = _weights[set_num - 1][k];
+                double running_product = _weights[set_num - 1][k]; // TODO: rowwise op?
                 for (size_t j = 0; j < prev_pars.cols(); j++) {
                     double par_value = pars(i,j);
                     double old_par_value = prev_pars(k, j);
@@ -1178,9 +1179,13 @@ void AbcSmc::calculate_predictive_prior_weights(int set_num) {
                 }
                 denominator += running_product;
             }
-            _weights[set_num][i] = numerator / denominator;
+
+            weight[i] = numerator / denominator;
         }
-        normalize_weights( _weights[set_num] );
+
+        weight.normalize();
+
+        _weights.push_back(weight);
     }
 }
 
@@ -1193,18 +1198,12 @@ gsl_matrix* AbcSmc::setup_mvn_sampler(const int set_num) {
     gsl_matrix* sigma_hat = gsl_matrix_alloc(num_pars, num_pars);
 
     if (use_mvn_noise) {
+
         // INITIALIZE DATA STRUCTURES
         Mat2D par = _particle_parameters[set_num-1](_predictive_prior[set_num-1], Eigen::placeholders::all);
         // container for predictive prior aka posterior from last set
-        gsl_matrix* posterior_par_vals = gsl_matrix_alloc(par.rows(), par.cols());
+        gsl_matrix* posterior_par_vals = ABC::to_gsl_m(par);
 
-
-        for (size_t i = 0; i < par.rows(); ++i) {
-            for (size_t j = 0; j < par.cols(); ++j) {
-                // copy values from pred prior into a gsl matrix
-                gsl_matrix_set(posterior_par_vals, i, j, par(i,j));
-            }
-        }
         // calculate maximum likelihood estimate of variance-covariance matrix sigma_hat
         gsl_ran_multivariate_gaussian_vcov(posterior_par_vals, sigma_hat);
 
@@ -1227,43 +1226,37 @@ gsl_matrix* AbcSmc::setup_mvn_sampler(const int set_num) {
 
 
 Row AbcSmc::sample_mvn_predictive_priors( int set_num, const gsl_rng* RNG, gsl_matrix* L ) {
-    // container for sampled values
-    Row par_values = Row::Zero(npar());
     // SELECT PARTICLE FROM PRED PRIOR TO USE AS EXPECTED VALUE OF NEW SAMPLE
-    const int r = _predictive_prior[set_num-1][gsl_rng_nonuniform_int(_weights[set_num-1], RNG)];
-    const Row par = _particle_parameters[set_num-1](r, Eigen::placeholders::all);
-    gsl_vector* par_val_hat = gsl_vector_alloc(par.cols());
-    for (size_t j = 0; j < par.cols(); j++) {
-        gsl_vector_set(par_val_hat, j, par[j]);
-    }
-    par_values = rand_trunc_mv_normal( _model_pars, par_val_hat, L, RNG );
+    const Row par = sample_posterior(
+        _weights[set_num-1],
+        _particle_parameters[set_num-1](_predictive_prior[set_num-1], Eigen::placeholders::all),
+        RNG
+    );
+    gsl_vector* par_val_hat = to_gsl_v(par);
+    Row par_values = rand_trunc_mv_normal( _model_pars, par_val_hat, L, RNG );
     gsl_vector_free(par_val_hat);
 
     return par_values;
 }
 
 Row AbcSmc::sample_predictive_priors( int set_num, const gsl_rng* RNG ) {
-    Row par_values = Row::Zero(npar());
-    // Select a particle index r to use from the predictive prior
-    int r = _predictive_prior[set_num-1][gsl_rng_nonuniform_int(_weights[set_num-1], RNG)];
-    const Row par = _particle_parameters[set_num-1](r, Eigen::placeholders::all);
+    const Row par = sample_posterior(
+        _weights[set_num-1],
+        _particle_parameters[set_num-1](_predictive_prior[set_num-1], Eigen::placeholders::all),
+        RNG
+    );
+    Row new_par = Row::Zero(npar());
     for (size_t j = 0; j < par.cols(); j++) {
         const Parameter* parameter = _model_pars[j];
         double doubled_variance = parameter->get_doubled_variance(set_num-1);
         double par_min = parameter->get_prior_min();
         double par_max = parameter->get_prior_max();
-        par_values(j) = rand_trunc_normal(par[j], doubled_variance, par_min, par_max, RNG );
+        new_par(j) = rand_trunc_normal(par[j], doubled_variance, par_min, par_max, RNG );
 
         if (parameter->get_numeric_type() == INT) {
-            par_values(j) = (double) ((int) (par_values(j) + 0.5));
+            new_par(j) = (double) ((int) (new_par(j) + 0.5));
         }
     }
-    return par_values;
-}
-
-Row AbcSmc::_z_transform_observed_metrics(Row& means, Row& stdevs) {
-    Row zmat = Row::Zero(nmet());
-    for (size_t i = 0; i < nmet(); i++) { zmat(i) = (_model_mets[i]->get_obs_val() - means(i)) / stdevs(i); }
-    return zmat;
+    return new_par;
 }
 

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -1112,17 +1112,6 @@ void AbcSmc::calculate_doubled_variances( int t ) {
     }
 }
 
-void AbcSmc::normalize_weights( vector<double>& weights ) {
-    double total = 0;
-    for (size_t i = 0; i < weights.size(); i++) {
-        total += weights[i];
-    }
-
-    for (size_t i = 0; i < weights.size(); i++) {
-        weights[i] /= total;
-    }
-}
-
 void AbcSmc::calculate_predictive_prior_weights(int set_num) {
     // We need to calculate the proper weights for the predictive prior so that we know how to sample from it.
     calculate_doubled_variances( set_num );

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -10,6 +10,7 @@
 #include "pls.h"
 #include "RunningStat.h"
 #include "AbcSmc.h"
+#include "AbcMPI.h"
 
 // need a positive int that is very unlikely
 // to be less than the number of particles
@@ -595,138 +596,34 @@ bool AbcSmc::read_SMC_sets_from_database (sqdb::Db &db, vector< vector<int> > &s
 }*/
 
 
-void AbcSmc::_particle_scheduler(int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
-#ifdef USING_MPI
-    MPI_Status status;
-    long double *send_data = new long double[npar() * _num_particles](); // all params, flattened array
-    long double *rec_data  = new long double[nmet() * _num_particles](); // all metrics, flattened array
+void AbcSmc::_particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG) {
+
+    auto _num_particles = get_num_particles(t);
 
     // sample parameter distributions; copy values into Y matrix and into send_data buffer
     Row par_row;
-    for (size_t i = 0; i<_num_particles; i++) {
-        if (t == 0) { // sample priors
-            par_row = sample_priors(RNG);
-            if (i < _num_particles) Y_orig.row(i) = par_row;
-        } else {      // sample predictive priors
-            par_row = sample_predictive_priors(t, RNG);
-            if (i < _num_particles) Y_orig.row(i) = par_row;
-        }
-        for (size_t j = 0; j < npar(); j++) { send_data[i*npar() + j] = par_row(j); }
-    }
-    // Seed the workers with the first 'num_workers' jobs
-    int particle_id = 0;
-    // Don't send particles that don't exist!
-    for (int rank = 1; rank < _mp->mpi_size and rank <= _num_particles; ++rank) {
-        particle_id = rank - 1;                       // which row in Y
-        MPI_Send(&send_data[particle_id*npar()],  // message buffer
-                 npar(),                          // number of elements
-                 MPI_LONG_DOUBLE,                 // data item is a double
-                 rank,                            // destination process rank
-                 particle_id,                     // message tag
-                 _mp->comm);                      // always use this
-    }
-
-    // Receive a result from any worker and dispatch a new work request
-    long double rec_buffer[nmet()];
-    particle_id++; // move cursor to next particle to be sent
-    while ( particle_id < _num_particles ) {
-        MPI_Recv(&rec_buffer,                     // message buffer
-                 nmet(),                          // message size
-                 MPI_LONG_DOUBLE,                 // of type double
-                 MPI_ANY_SOURCE,                  // receive from any sender
-                 MPI_ANY_TAG,                     // any type of message
-                 _mp->comm,                       // always use this
-                 &status);                        // received message info
-        for (int m = 0; m<nmet(); ++m) rec_data[status.MPI_TAG*nmet() + m] = rec_buffer[m];
-
-        MPI_Send(&send_data[particle_id*npar()],  // message buffer
-                 npar(),                          // number of elements
-                 MPI_LONG_DOUBLE,                 // data item is a double
-                 status.MPI_SOURCE,               // send it to the rank that just finished
-                 particle_id,                     // message tag
-                 _mp->comm);                      // always use this
-        particle_id++; // move cursor
-    }
-
-    // receive results for outstanding work requests--there are exactly 'num_workers'
-    // or '_num_particles' left, whichever is smaller
-    for (int rank = 1; rank < _mp->mpi_size and rank <= _num_particles; ++rank) {
-        MPI_Recv(&rec_buffer,
-                 nmet(),
-                 MPI_LONG_DOUBLE,
-                 MPI_ANY_SOURCE,
-                 MPI_ANY_TAG,
-                 _mp->comm,
-                 &status);
-        for (int m = 0; m<nmet(); ++m) rec_data[status.MPI_TAG*nmet() + m] = rec_buffer[m];
-    }
-
-    // Tell all the workers they're done for now
-    for (int rank = 1; rank < _mp->mpi_size; ++rank) {
-        MPI_Send(0, 0, MPI_INT, rank, STOP_TAG, _mp->comm);
-    }
-
-    vector<int> bad_particle_idx; // bandaid, in case simulator returns nonsense values
     for (size_t i = 0; i < _num_particles; i++) {
-        for (size_t j = 0; j < nmet(); j++) {
-            const double met_val = rec_data[i*nmet() + j];
-            if (not isfinite(met_val)) bad_particle_idx.push_back(i);
-            X_orig(i,j) = rec_data[i*nmet() + j];
+        if (t == 0) { // sample priors
+            Mat2D posterior = slurp_posterior();
+            int posterior_rank = -1;
+            Y_orig.row(i) = sample_priors(RNG, posterior, posterior_rank);
+        } else {      // sample predictive priors
+            Y_orig.row(i) = sample_predictive_priors(t, RNG);
         }
     }
 
-    // bandaid, in case simulator returns nonsense values
-    for (size_t i = 0; i < bad_particle_idx.size(); i++) {
-        X_orig.row(i).fill(numeric_limits<float_type>::min());
-        Y_orig.row(i).fill(numeric_limits<float_type>::min());
-    }
+    X_orig.resize(_num_particles, nmet());
 
-    delete[] send_data;
-    delete[] rec_data;
-#endif
+    ABC::particle_scheduler(X_orig, Y_orig, _mp);
+
 }
 
 
-void AbcSmc::_particle_worker() {
-#ifdef USING_MPI
-    MPI_Status status;
-    long double *local_Y_data = new long double[npar()]();
-    long double *local_X_data = new long double[nmet()]();
-
-    while (1) {
-        MPI_Recv(local_Y_data,
-                 npar(),
-                 MPI_LONG_DOUBLE,
-                 mpi_root,
-                 MPI_ANY_TAG,
-                 _mp->comm,
-                 &status);
-
-        // Check the tag of the received message.
-        if (status.MPI_TAG == STOP_TAG) {
-            delete[] local_Y_data;
-            delete[] local_X_data;
-            return;
-        }
-
-        Row pars(npar());
-        Row mets(nmet());
-
-        for (size_t j = 0; j < npar(); j++) { pars[j] = local_Y_data[j]; }
-
-        bool success = _run_simulator(pars, mets);
-        if (not success) exit(-210);
-
-        for (size_t j = 0; j < nmet(); j++) { local_X_data[j] = mets[j]; }
-
-        MPI_Send(local_X_data,
-                 nmet(),
-                 MPI_LONG_DOUBLE,
-                 mpi_root,
-                 status.MPI_TAG,
-                 _mp->comm);
-    }
-#endif
+void AbcSmc::_particle_worker(
+    const size_t seed,
+    const size_t serial
+) {
+    ABC::particle_worker(npar(), nmet(), _simulator, seed, serial, _mp);
 }
 
 

--- a/AbcSmc.cpp
+++ b/AbcSmc.cpp
@@ -935,8 +935,10 @@ PLS_Model& AbcSmc::run_PLS(
     
 }
 
-PLS_Model AbcSmc::_filter_particles (
-    int t, Mat2D &X_orig, Mat2D &Y_orig, int next_pred_prior_size,
+PLS_Model AbcSmc::_filter_particles(
+    const size_t t,
+    const Mat2D & X_orig, const Mat2D & Y_orig,
+    const size_t next_pred_prior_size,
     const bool verbose
 ) {
     Row X_sim_means = X_orig.colwise().mean();
@@ -967,8 +969,6 @@ PLS_Model AbcSmc::_filter_particles (
     Row   obs_scores = plsm.scores(obs_met, num_components_used).row(0).real();
     Mat2D sim_scores = plsm.scores(X, num_components_used).real();
     Col   distances  = ABC::euclidean(sim_scores, obs_scores);
-
-
 
     _set_predictive_prior(t, next_pred_prior_size, distances);
 

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -398,7 +398,11 @@ class AbcSmc {
 
         Mat2D slurp_posterior();
 
-        Row sample_priors( const gsl_rng* RNG, Mat2D& posterior, int &posterior_rank );
+        Mat2D sample_priors(
+            const gsl_rng* RNG, const size_t num_samples,
+            const Mat2D & posterior,
+            std::vector<int> & posterior_ranks
+        );
 
         std::vector<double> do_complicated_untransformations(const std::vector<Parameter*> & _model_pars, const Row & pars );
 

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -215,7 +215,7 @@ class AbcSmc {
         size_t get_smc_iterations() { return _num_smc_sets; }
         //void set_smc_set_sizes(vector<int> n) { _smc_set_sizes = n; }
 
-        size_t get_num_particles(size_t set_num, VerboseType vt = VERBOSE) {
+        size_t get_num_particles(const size_t set_num, const VerboseType vt = VERBOSE) {
             int set_size = 0;
             if (set_num < _smc_set_sizes.size()) {
                 set_size = _smc_set_sizes[set_num];
@@ -357,9 +357,10 @@ class AbcSmc {
 
         bool _populate_particles( int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG );
 
-        bool _populate_particles_mpi( int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG );
-        void _particle_scheduler(int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
-        void _particle_worker();
+//      TODO: undefined?
+//        bool _populate_particles_mpi( int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG );
+        void _particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
+        void _particle_worker(const size_t seed, const size_t serial);
 
         void _fp_helper(const int t, const Mat2D &X_orig, const Mat2D &Y_orig, const int next_pred_prior_size, const Col& distances);
         void _filter_particles_simple(int t, Mat2D &X_orig, Mat2D &Y_orig, int pred_prior_size);

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -397,7 +397,7 @@ class AbcSmc {
 
         std::vector<double> do_complicated_untransformations(const std::vector<Parameter*> & _model_pars, const Row & pars );
 
-        void calculate_doubled_variances( int t );
+        void calculate_doubled_variances( const size_t previous_set );
 
         void calculate_predictive_prior_weights( int set_num );
 

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -363,8 +363,8 @@ class AbcSmc {
 
 //      TODO: undefined?
 //        bool _populate_particles_mpi( int t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG );
-        void _particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
-        void _particle_worker(const size_t seed, const size_t serial);
+        void _particle_scheduler_mpi(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
+        void _particle_worker_mpi(const size_t seed, const size_t serial);
 
         void _set_predictive_prior(const int t, const int next_pred_prior_size, const Col& distances);
         void _filter_particles_simple(int t, Mat2D &X_orig, Mat2D &Y_orig, int pred_prior_size);

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -397,8 +397,6 @@ class AbcSmc {
 
         void calculate_doubled_variances( int t );
 
-        void normalize_weights( std::vector<double>& weights );
-
         void calculate_predictive_prior_weights( int set_num );
 
         gsl_matrix* setup_mvn_sampler(const int);

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -321,7 +321,7 @@ class AbcSmc {
         std::vector< Mat2D > get_particle_metrics()    { return _particle_metrics; }
 
         Row get_doubled_variance(const size_t t) const { return _doubled_variance[t]; }
-        Row append_doubled_variance(const Row & v2) { _doubled_variance.push_back(v2); }
+        void append_doubled_variance(const Row & v2) { _doubled_variance.push_back(v2); }
 
 
     private:
@@ -395,16 +395,13 @@ class AbcSmc {
 
         Row sample_priors( const gsl_rng* RNG, Mat2D& posterior, int &posterior_rank );
 
-        std::vector<double> do_complicated_untransformations( std::vector<Parameter*>& _model_pars, Row& pars );
+        std::vector<double> do_complicated_untransformations(const std::vector<Parameter*> & _model_pars, const Row & pars );
 
         void calculate_doubled_variances( int t );
 
         void calculate_predictive_prior_weights( int set_num );
 
         gsl_matrix* setup_mvn_sampler(const int);
-        Row sample_mvn_predictive_priors( int set_num, const gsl_rng* RNG, gsl_matrix* L );
-
-        Row sample_predictive_priors( int set_num, const gsl_rng* RNG );
 
 };
 

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -389,8 +389,6 @@ class AbcSmc {
         bool _update_sets_table(sqdb::Db &db, int t);
         //bool read_SMC_sets_from_database(sqdb::Db &db, std::vector<std::vector<int> > &serials);
 
-        Col euclidean( Row obs_met, Mat2D sim_met );
-
         Mat2D slurp_posterior();
 
         Row sample_priors( const gsl_rng* RNG, Mat2D& posterior, int &posterior_rank );

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -350,7 +350,7 @@ class AbcSmc {
         std::vector< Mat2D > _particle_metrics;
         std::vector< Mat2D > _particle_parameters;
         std::vector< std::vector<int> > _predictive_prior; // vector of row indices for particle metrics and parameters
-        std::vector< std::vector<double> > _weights;
+        std::vector<Col> _weights;
         bool use_mvn_noise;
         bool use_pls_filtering;
 
@@ -408,7 +408,6 @@ class AbcSmc {
 
         Row sample_predictive_priors( int set_num, const gsl_rng* RNG );
 
-        Row _z_transform_observed_metrics( Row& means, Row& stdevs );
 };
 
 #endif

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -74,9 +74,6 @@ class Parameter {
             }
         }
 
-        // doubled variance of particles
-        double get_doubled_variance(int t) const { return doubled_variance[t]; }
-        void append_doubled_variance(double v2) { doubled_variance.push_back(v2); }
         void set_prior_limits(double min, double max) { fmin = min; fmax = max; }
         double get_prior_min() const { return fmin; }
         double get_prior_max() const { return fmax; }
@@ -109,7 +106,6 @@ class Parameter {
         PriorType ptype;
         NumericType ntype;
         double fmin, fmax, mean, stdev, state, step;
-        std::vector<double> doubled_variance;
         double (*untran_func) (const double);
         std::pair<double, double> rescale;
         std::map < std::string, std::vector<int> > par_modification_map; // how this par modifies others
@@ -324,6 +320,10 @@ class AbcSmc {
         std::vector< Mat2D > get_particle_parameters() { return _particle_parameters; }
         std::vector< Mat2D > get_particle_metrics()    { return _particle_metrics; }
 
+        Row get_doubled_variance(const size_t t) const { return _doubled_variance[t]; }
+        Row append_doubled_variance(const Row & v2) { _doubled_variance.push_back(v2); }
+
+
     private:
         friend AbcLog;
         Mat2D X_orig;
@@ -351,6 +351,8 @@ class AbcSmc {
         std::vector< Mat2D > _particle_parameters;
         std::vector< std::vector<int> > _predictive_prior; // vector of row indices for particle metrics and parameters
         std::vector<Col> _weights;
+        std::vector<Row> _doubled_variance;
+
         bool use_mvn_noise;
         bool use_pls_filtering;
 

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -369,8 +369,13 @@ class AbcSmc {
         void _particle_worker_mpi(const size_t seed, const size_t serial);
 
         void _set_predictive_prior(const int t, const int next_pred_prior_size, const Col& distances);
+
         void _filter_particles_simple(int t, Mat2D &X_orig, Mat2D &Y_orig, int pred_prior_size);
-        PLS_Model _filter_particles(int t, Mat2D &X_orig, Mat2D &Y_orig, int pred_prior_size, const bool verbose = true);
+        PLS_Model _filter_particles(
+            const size_t t, const Mat2D & X_orig, const Mat2D & Y_orig,
+            const size_t pred_prior_size, const bool verbose = true
+        );
+
         long double calculate_nrmse(vector<Col> posterior_mets);
 
         void set_resume(const bool res) { resume_flag = res; }

--- a/AbcSmc.h
+++ b/AbcSmc.h
@@ -10,6 +10,8 @@
 #include "AbcSim.h"
 #include "pls.h"
 
+class AbcLog; // forward declaration of AbcLog; see AbcLog.h
+
 enum PriorType {UNIFORM, NORMAL, PSEUDO, POSTERIOR};
 enum NumericType {INT, FLOAT};
 enum VerboseType {QUIET, VERBOSE};
@@ -264,6 +266,8 @@ class AbcSmc {
         Metric* add_next_metric(std::string name, std::string short_name, NumericType ntype, double obs_val) {
             Metric* m = new Metric(name, short_name, ntype, obs_val);
             _model_mets.push_back(new Metric(name, short_name, ntype, obs_val));
+            _met_vals.resize(_model_mets.size());
+            _met_vals[_model_mets.size()-1] = obs_val;
             return m;
         }
         Parameter* add_next_parameter(std::string name, std::string short_name, PriorType ptype, NumericType ntype, double val1, double val2, double step,double (*u)(const double), std::pair<double, double> r, std::map<std::string, std::vector<int> > mm) {
@@ -287,8 +291,6 @@ class AbcSmc {
 
         void process_predictive_prior_arguments(Json::Value par);
         bool parse_config(std::string conf_filename);
-        void report_convergence_data(const size_t t);
-
 
         bool build_database(const gsl_rng* RNG);
         bool process_database(const gsl_rng* RNG);
@@ -323,10 +325,12 @@ class AbcSmc {
         std::vector< Mat2D > get_particle_metrics()    { return _particle_metrics; }
 
     private:
+        friend AbcLog;
         Mat2D X_orig;
         Mat2D Y_orig;
         std::vector<Parameter*> _model_pars;
         std::vector<Metric*> _model_mets;
+        Row _met_vals;
         size_t _num_smc_sets;
         vector<int> _smc_set_sizes;
         //int _num_particles;
@@ -362,10 +366,9 @@ class AbcSmc {
         void _particle_scheduler(const size_t t, Mat2D &X_orig, Mat2D &Y_orig, const gsl_rng* RNG);
         void _particle_worker(const size_t seed, const size_t serial);
 
-        void _fp_helper(const int t, const Mat2D &X_orig, const Mat2D &Y_orig, const int next_pred_prior_size, const Col& distances);
+        void _set_predictive_prior(const int t, const int next_pred_prior_size, const Col& distances);
         void _filter_particles_simple(int t, Mat2D &X_orig, Mat2D &Y_orig, int pred_prior_size);
         PLS_Model _filter_particles(int t, Mat2D &X_orig, Mat2D &Y_orig, int pred_prior_size, const bool verbose = true);
-        void _print_particle_table_header();
         long double calculate_nrmse(vector<Col> posterior_mets);
 
         void set_resume(const bool res) { resume_flag = res; }

--- a/AbcUtil.cpp
+++ b/AbcUtil.cpp
@@ -269,7 +269,7 @@ Mat2D colwise_z_scores(const Mat2D & mat) {
   }
 
   template<typename Iterable>
-  int gsl_rng_nonuniform_int(const Iterable & weights, const gsl_rng* rng) {
+  int gsl_rng_nonuniform_int(const gsl_rng* rng, const Iterable & weights) {
       // Weights must sum to 1!!
       double running_sum = 0;
       double r = gsl_rng_uniform(rng);
@@ -510,9 +510,30 @@ gsl_matrix* ABC::to_gsl_m(const Mat2D & from){
 };
 
 Row ABC::sample_posterior(
+    const gsl_rng* RNG,
     const Col weights,
-    const Mat2D posterior,
-    const gsl_rng* RNG
+    const Mat2D posterior
 ) {
-    return posterior(gsl_rng_nonuniform_int(weights, RNG), Eigen::placeholders::all);
+    return posterior(gsl_rng_nonuniform_int(RNG, weights), Eigen::placeholders::all);
 };
+
+Row ABC::sample_predictive_priors(
+    const gsl_rng* RNG,
+    const Col & weights, const Mat2D & parameter_prior,
+    const std::vector<Parameter*> & pars,
+    const Row & doubled_variance
+) {
+    const Row par = ABC::sample_posterior(RNG, weights, parameter_prior);
+    Row new_par = Row::Zero(par.cols());
+    for (size_t parIdx = 0; parIdx < par.cols(); parIdx++) {
+        const Parameter* parameter = pars[parIdx];
+        double par_min = parameter->get_prior_min();
+        double par_max = parameter->get_prior_max();
+        new_par(parIdx) = ABC::rand_trunc_normal(par[parIdx], doubled_variance[parIdx], par_min, par_max, RNG );
+
+        if (parameter->get_numeric_type() == INT) {
+            new_par(parIdx) = (double) ((int) (new_par(parIdx) + 0.5));
+        }
+    }
+    return new_par;
+}

--- a/AbcUtil.cpp
+++ b/AbcUtil.cpp
@@ -460,3 +460,24 @@ namespace ABC {
   }
 
 }
+
+double ABC::calculate_nrmse(
+    const Mat2D & posterior_mets, // rows are posterior samples, columns are metrics
+    const Row & observed
+) {
+    assert(posterior_mets.cols() == observed.size());
+
+    // get the simulated mean of each metric
+    Row sim = posterior_mets.colwise().mean();
+    // take the average of the observed and simulated values as the "reference"
+    // tjh TODO: where does the fabs come from?
+    Row expected = (observed.array().abs() + sim.array().abs()) / 2.0;
+    // where sim == obs, set expected == 1 (precludes divide by zero, and otherwise doesn't matter)
+    for (size_t i = 0; i < expected.size(); ++i) { if (sim[i] == observed[i]) expected[i] = 1; }
+
+    // delta = (sim - obs) / expected => each squared => collapse to mean => sqrt
+    double res = mean(((sim - observed).array() / expected.array()).square());
+
+    return sqrt(res);
+
+}

--- a/AbcUtil.cpp
+++ b/AbcUtil.cpp
@@ -461,6 +461,12 @@ Mat2D colwise_z_scores(const Mat2D & mat) {
       return logistic_reg(data);
   }
 
+  Col euclidean(const Mat2D & sims, const Row & ref) {
+    // for each row in sims, subtract the reference row
+    // norm = sqrt(sum_i xi^2)
+    return (sims.rowwise() - ref).rowwise().norm();
+  }
+
 }
 
 double ABC::calculate_nrmse(

--- a/AbcUtil.cpp
+++ b/AbcUtil.cpp
@@ -268,17 +268,15 @@ Mat2D colwise_z_scores(const Mat2D & mat) {
       return optimize_box_cox(data, -5, 5, 0.1);
   }
 
-  template<typename Iterable>
-  int gsl_rng_nonuniform_int(const gsl_rng* rng, const Iterable & weights) {
-      // Weights must sum to 1!!
-      double running_sum = 0;
-      double r = gsl_rng_uniform(rng);
-      for (size_t i = 0; i < weights.size(); i++) {
-          running_sum += weights[i];
-          if (r <= running_sum) return i;
-      }
-      cerr << "ERROR: Weights may not be normalized\n\t Weights summed to: " << running_sum << endl;
-      exit(100);
+  std::vector<size_t> gsl_rng_nonuniform_int(
+    const gsl_rng* RNG, const size_t num_samples,
+    const Col & weights
+  ) {
+    gsl_ran_discrete_t* gslweights = gsl_ran_discrete_preproc(weights.rows(), weights.data());
+    std::vector<size_t> res(num_samples);
+    for (size_t i = 0; i < res.size(); i++) { res[i] = gsl_ran_discrete(RNG, gslweights); }
+    gsl_ran_discrete_free(gslweights);
+    return res;
   }
 
   Row gsl_ran_trunc_mv_normal(
@@ -529,32 +527,42 @@ gsl_matrix* ABC::to_gsl_m(const Mat2D & from){
     return res;
 };
 
-Row ABC::sample_posterior(
-    const gsl_rng* RNG,
-    const Col weights,
-    const Mat2D posterior
+Mat2D ABC::sample_posterior(
+    const gsl_rng* RNG, const size_t num_samples,
+    const Col & weights,
+    const Mat2D & posterior
 ) {
-    return posterior(gsl_rng_nonuniform_int(RNG, weights), Eigen::placeholders::all);
+    return posterior( // from the posterior
+        gsl_rng_nonuniform_int(RNG, num_samples, weights), // get a weighted-random draw of rows
+        Eigen::placeholders::all
+    );
 };
 
-Row ABC::sample_predictive_priors(
-    const gsl_rng* RNG,
+Mat2D ABC::sample_predictive_priors(
+    const gsl_rng* RNG, const size_t num_samples,
     const Col & weights, const Mat2D & parameter_prior,
     const std::vector<Parameter*> & pars,
     const Row & doubled_variance
 ) {
-    const Row par = ABC::sample_posterior(RNG, weights, parameter_prior);
-    return ABC::gsl_ran_trunc_normal(RNG, pars, par, doubled_variance);
+    const Mat2D sampled_pars = ABC::sample_posterior(RNG, num_samples, weights, parameter_prior);
+    Mat2D noised_pars = Mat2D(sampled_pars.rows(), sampled_pars.cols());
+    for (size_t i = 0; i < noised_pars.rows(); i++) {
+        noised_pars.row(i) = gsl_ran_trunc_normal(RNG, pars, sampled_pars.row(i), doubled_variance);
+    }
+    return noised_pars;
 };
 
-Row ABC::sample_mvn_predictive_priors(
-    const gsl_rng* RNG,
+Mat2D ABC::sample_mvn_predictive_priors(
+    const gsl_rng* RNG, const size_t num_samples,
     const Col & weights, const Mat2D & parameter_prior,
     const std::vector<Parameter*> & pars,
     const gsl_matrix* L
 ) {
     // SELECT PARTICLE FROM PRED PRIOR TO USE AS EXPECTED VALUE OF NEW SAMPLE
-    const Row par = ABC::sample_posterior(RNG, weights, parameter_prior);
-    return gsl_ran_trunc_mv_normal(RNG, pars, par, L);
-    
+    const Mat2D sampled_pars = ABC::sample_posterior(RNG, num_samples, weights, parameter_prior);
+    Mat2D noised_pars = Mat2D(sampled_pars.rows(), sampled_pars.cols());
+    for (size_t i = 0; i < noised_pars.rows(); i++) {
+        noised_pars.row(i) = gsl_ran_trunc_mv_normal(RNG, pars, sampled_pars.row(i), L);
+    }
+    return noised_pars;
 };

--- a/AbcUtil.h
+++ b/AbcUtil.h
@@ -96,14 +96,16 @@ namespace ABC {
 
   inline double uniform_pdf(double a, double b) { return 1.0 / fabs(b-a); }
 
-  template<typename Iterable>
-  int gsl_rng_nonuniform_int(const gsl_rng* rng, const Iterable & weights);
+  std::vector<size_t> gsl_rng_nonuniform_int(const gsl_rng* RNG, const size_t num_samples, const Col & weights);
+
+  std::vector<size_t> gsl_ran_seeds();
 
   Row gsl_ran_trunc_normal(
     const gsl_rng* RNG,
     const std::vector<Parameter*> _model_pars,
     const Row & mu, const Row & sigma_squared
   );
+
   Row gsl_ran_trunc_mv_normal(
     const gsl_rng* RNG,
     const vector<Parameter*> _model_pars,
@@ -134,10 +136,10 @@ namespace ABC {
     const Row & observed
   );
 
-  Row sample_posterior(
-    const gsl_rng* RNG,
-    const Col weights,
-    const Mat2D posterior
+  Mat2D sample_posterior(
+    const gsl_rng* RNG, const size_t num_samples,
+    const Col & weights,
+    const Mat2D & posterior
   );
 
   template<typename RandomAccessible>
@@ -147,15 +149,15 @@ namespace ABC {
 
     Col euclidean(const Mat2D & sims, const Row & ref);
 
-Row sample_predictive_priors(
-    const gsl_rng* RNG,
+Mat2D sample_predictive_priors(
+    const gsl_rng* RNG, const size_t num_samples,
     const Col & weights, const Mat2D & parameter_prior,
     const std::vector<Parameter*> & pars,
     const Row & doubled_variance
 );
 
-Row sample_mvn_predictive_priors(
-    const gsl_rng* RNG,
+Mat2D sample_mvn_predictive_priors(
+    const gsl_rng* RNG, const size_t num_samples,
     const Col & weights, const Mat2D & parameter_prior,
     const std::vector<Parameter*> & pars,
     const gsl_matrix* L

--- a/AbcUtil.h
+++ b/AbcUtil.h
@@ -99,8 +99,17 @@ namespace ABC {
   template<typename Iterable>
   int gsl_rng_nonuniform_int(const gsl_rng* rng, const Iterable & weights);
 
-  double rand_trunc_normal(double mu, double sigma_squared, double min, double max, const gsl_rng* rng);
-  Row rand_trunc_mv_normal(const vector<Parameter*> _model_pars, gsl_vector* mu, gsl_matrix* L, const gsl_rng* rng);
+  Row gsl_ran_trunc_normal(
+    const gsl_rng* RNG,
+    const std::vector<Parameter*> _model_pars,
+    const Row & mu, const Row & sigma_squared
+  );
+  Row gsl_ran_trunc_mv_normal(
+    const gsl_rng* RNG,
+    const vector<Parameter*> _model_pars,
+    const Row & mu,
+    const gsl_matrix* L
+  );
 
   LinearFit* lin_reg(const std::vector<double> &x, const std::vector<double> &y);
 
@@ -143,6 +152,13 @@ Row sample_predictive_priors(
     const Col & weights, const Mat2D & parameter_prior,
     const std::vector<Parameter*> & pars,
     const Row & doubled_variance
+);
+
+Row sample_mvn_predictive_priors(
+    const gsl_rng* RNG,
+    const Col & weights, const Mat2D & parameter_prior,
+    const std::vector<Parameter*> & pars,
+    const gsl_matrix* L
 );
 
 }

--- a/AbcUtil.h
+++ b/AbcUtil.h
@@ -52,16 +52,15 @@ namespace ABC {
   inline float_type logit(const float_type p) { assert(p <= 1.0); assert (p >= 0.0); return log( p / (1.0 - p) ); }
   inline float_type logistic(const float_type l) { return 1.0 / (1.0 + exp(-l)); }
 
-  inline Row col_means( Mat2D mat ) { return mat.colwise().sum() / mat.rows(); }
-
   //int _sgn(float_type val) { return (0 < val) - (val < 0); }
 
   Mat2D read_matrix_file(std::string filename, char sep);
 
-  Row col_stdev( Mat2D mat, Row means );
+  Row colwise_stdev(const Mat2D & mat, const Row & means);
 
-  Mat2D colwise_z_scores( const Mat2D& mat );
-  Mat2D colwise_z_scores( const Mat2D& mat, Row& means, Row& stdev );
+  Mat2D colwise_z_scores( const Mat2D & mat, const Row & mean, const Row & stdev);
+  Mat2D colwise_z_scores( const Mat2D & mat );
+  Row z_scores(const Row & metobs, const Row & means, const Row & stdevs);
 
   float_type mean(const Col data);
 
@@ -97,7 +96,8 @@ namespace ABC {
 
   inline double uniform_pdf(double a, double b) { return 1.0 / fabs(b-a); }
 
-  int gsl_rng_nonuniform_int(std::vector<double>& weights, const gsl_rng* rng);
+  template<typename Iterable>
+  int gsl_rng_nonuniform_int(const Iterable & weights, const gsl_rng* rng);
 
   double rand_trunc_normal(double mu, double sigma_squared, double min, double max, const gsl_rng* rng);
   Row rand_trunc_mv_normal(const vector<Parameter*> _model_pars, gsl_vector* mu, gsl_matrix* L, const gsl_rng* rng);
@@ -124,6 +124,17 @@ namespace ABC {
     const Mat2D & posterior_mets,
     const Row & observed
   );
+
+  Row sample_posterior(
+    const Col weights,
+    const Mat2D posterior,
+    const gsl_rng* RNG
+  );
+
+  template<typename RandomAccessible>
+  gsl_vector* to_gsl_v(const RandomAccessible & from);
+
+  gsl_matrix* to_gsl_m(const Mat2D & from);
 
 }
 

--- a/AbcUtil.h
+++ b/AbcUtil.h
@@ -136,6 +136,8 @@ namespace ABC {
 
   gsl_matrix* to_gsl_m(const Mat2D & from);
 
+    Col euclidean(const Mat2D & sims, const Row & ref);
+
 }
 
 #endif

--- a/AbcUtil.h
+++ b/AbcUtil.h
@@ -97,7 +97,7 @@ namespace ABC {
   inline double uniform_pdf(double a, double b) { return 1.0 / fabs(b-a); }
 
   template<typename Iterable>
-  int gsl_rng_nonuniform_int(const Iterable & weights, const gsl_rng* rng);
+  int gsl_rng_nonuniform_int(const gsl_rng* rng, const Iterable & weights);
 
   double rand_trunc_normal(double mu, double sigma_squared, double min, double max, const gsl_rng* rng);
   Row rand_trunc_mv_normal(const vector<Parameter*> _model_pars, gsl_vector* mu, gsl_matrix* L, const gsl_rng* rng);
@@ -126,9 +126,9 @@ namespace ABC {
   );
 
   Row sample_posterior(
+    const gsl_rng* RNG,
     const Col weights,
-    const Mat2D posterior,
-    const gsl_rng* RNG
+    const Mat2D posterior
   );
 
   template<typename RandomAccessible>
@@ -137,6 +137,13 @@ namespace ABC {
   gsl_matrix* to_gsl_m(const Mat2D & from);
 
     Col euclidean(const Mat2D & sims, const Row & ref);
+
+Row sample_predictive_priors(
+    const gsl_rng* RNG,
+    const Col & weights, const Mat2D & parameter_prior,
+    const std::vector<Parameter*> & pars,
+    const Row & doubled_variance
+);
 
 }
 

--- a/AbcUtil.h
+++ b/AbcUtil.h
@@ -120,6 +120,11 @@ namespace ABC {
       return row;
   }
 
+  double calculate_nrmse(
+    const Mat2D & posterior_mets,
+    const Row & observed
+  );
+
 }
 
 #endif

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ endif
 #LIBS = -lm -L$(TACC_GSL_LIB/) -L$(HPC_GSL_LIB/) -lgsl -lgslcblas
 LIBS = -lm -lgsl -lgslcblas
 
-ABCSOURCES =  pls.cpp AbcUtil.cpp AbcSmc.cpp CCRC32.cpp
+ABCSOURCES =  pls.cpp AbcUtil.cpp AbcSmc.cpp CCRC32.cpp AbcMPI.cpp
 JSONSOURCES = $(patsubst %,$(JSONDIR)/src/%.cpp,json_reader json_value json_writer)
 SQLSOURCES  = $(addprefix $(SQLDIR)/,sqdb.cpp sqlite3.c)
 
 ABCOBJECTS  = $(ABCSOURCES:.cpp=.o)
 JSONOBJECTS = $(JSONSOURCES:.cpp=.o)
 SQLOBJECTS  = $(SQLDIR)/sqdb.o $(SQLDIR)/sqlite3.o
-ABC_HEADER = ./pls.h ./AbcUtil.h ./AbcSmc.h ./AbcSim.h
+ABC_HEADER = ./pls.h ./AbcUtil.h ./AbcSmc.h ./AbcSim.h ./AbcMPI.h ./AbcMPIPar.h
 
 default: libabc.a
 

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ endif
 #LIBS = -lm -L$(TACC_GSL_LIB/) -L$(HPC_GSL_LIB/) -lgsl -lgslcblas
 LIBS = -lm -lgsl -lgslcblas
 
-ABCSOURCES =  pls.cpp AbcUtil.cpp AbcSmc.cpp CCRC32.cpp AbcMPI.cpp
+ABCSOURCES =  pls.cpp AbcUtil.cpp AbcSmc.cpp CCRC32.cpp AbcMPI.cpp AbcLog.cpp
 JSONSOURCES = $(patsubst %,$(JSONDIR)/src/%.cpp,json_reader json_value json_writer)
 SQLSOURCES  = $(addprefix $(SQLDIR)/,sqdb.cpp sqlite3.c)
 
 ABCOBJECTS  = $(ABCSOURCES:.cpp=.o)
 JSONOBJECTS = $(JSONSOURCES:.cpp=.o)
 SQLOBJECTS  = $(SQLDIR)/sqdb.o $(SQLDIR)/sqlite3.o
-ABC_HEADER = ./pls.h ./AbcUtil.h ./AbcSmc.h ./AbcSim.h ./AbcMPI.h ./AbcMPIPar.h
+ABC_HEADER = ./pls.h ./AbcUtil.h ./AbcSmc.h ./AbcSim.h ./AbcMPI.h ./AbcMPIPar.h ./AbcLog.h
 
 default: libabc.a
 

--- a/RunningStat.h
+++ b/RunningStat.h
@@ -30,6 +30,9 @@ class RunningStat {
             }
         }
 
+        template<typename Iterable>
+        void Push(const Iterable & xs) { for(double x : xs) Push(x); }
+
         int NumDataValues() const {
             return m_n;
         }

--- a/examples/dice.h
+++ b/examples/dice.h
@@ -19,7 +19,7 @@ extern "C" std::vector<double> simulator(
     const ABC::MPI_par* /* mp */
 ) {
     
-    gsl_rng_set(RNG, rng_seed); // seed the rng using sys time and the process id
+    gsl_rng_set(RNG, serial); // seed the rng using sys time and the process id
     const size_t par1 = static_cast<size_t>(args[0]); // number of dice
     const size_t par2 = static_cast<size_t>(args[1]); // number of sides on dice
 

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -56,10 +56,13 @@ CLIArgs parse_args(std::string cmd, int argc, char* argv[]) {
 };
 
 template<typename ABC>
-inline void abc_inner(ABC * abc, CLIArgs& args, const gsl_rng * RNG, size_t buffer_size) {
+inline void abc_inner(
+    ABC * abc, const CLIArgs& args, const gsl_rng * RNG, const size_t buffer_size,
+    const size_t smcset = 0 // TODO find a good way to pass this
+) {
 
     if (args.process_db) {
-        gsl_rng_set(RNG, time(NULL) * getpid()); // seed the rng using sys time and the process id
+        gsl_rng_set(RNG, smcset); // seed the rng using smcset
         abc->process_database(RNG);
     } 
 
@@ -70,15 +73,18 @@ inline void abc_inner(ABC * abc, CLIArgs& args, const gsl_rng * RNG, size_t buff
 };
 
 template<typename ABC>
-void abc_loop(ABC * abc, CLIArgs& args, const gsl_rng * RNG) {
+void abc_loop(
+    ABC * abc, CLIArgs& args, const gsl_rng * RNG,
+    const size_t smcset = 0 // TODO find a good way to pass this
+) {
 
     if (args.do_all) {
         size_t set_count = abc->get_smc_iterations();
         for (size_t i = 0; i < set_count; ++i) {
-            abc_inner(abc, args, RNG, abc->get_num_particles(i, QUIET));
+            abc_inner(abc, args, RNG, abc->get_num_particles(i, QUIET), i);
         }
     } else {
-        abc_inner(abc, args, RNG, args.buffer_size);
+        abc_inner(abc, args, RNG, args.buffer_size, smcset);
     }
 
     if (args.do_all) {

--- a/pls.cpp
+++ b/pls.cpp
@@ -92,17 +92,11 @@ float_type normalcdf(float_type z) {
 // Thomas E. V. Non-parametric statistical methods for multivariate calibration
 // model selection and comparison. J. Chemometrics 2003; 17: 653–659
 //
-float_type wilcoxon(const Col err_1, const Col err_2) {
-    assert(err_1.rows() == err_2.rows());
-
-    const size_t n = err_1.rows();
+float_type wilcoxon(const Col & err_1, const Col & err_2) {
+    assert(err_1.size() == err_2.size());
+    size_t n = err_1.rows();
     Col del = err_1.cwiseAbs() - err_2.cwiseAbs();
-    assert(static_cast<size_t>(del.size()) == n);
-
-    // TODO: setZero necessary?
-    Rowi sdel;
-    sdel.setZero(n);
-    //Matrix<int, Dynamic, 1> sdel = del.unaryExpr(std::ptr_fun(_sgn)); // can't get this to work
+    Rowi sdel = Rowi::Zero(n);
     for (size_t i = 0; i < n; i++) {
         sdel(i) = (0 < del(i)) - (del(i) < 0); // get the sign of each element
     }
@@ -110,8 +104,8 @@ float_type wilcoxon(const Col err_1, const Col err_2) {
     // 's' gives the original positions (indices) of the sorted values
     auto s = ordered(adel);
     float_type d = 0;
-    for (size_t i = 0; i < n; i++) { d += (i + 1) * sdel(s[i]); }
-    float_type t  = n * (n + 1) / 2.0;
+    for (size_t i = 0; i < n; i++) { d += static_cast<float_type>(i + 1) * sdel(s[i]); }
+    float_type t  = static_cast<float_type>(n * (n + 1)) / 2.0;
     float_type v  = (t - d) / 2.0;
     float_type ev = t/2.0;
     float_type sv = sqrt(static_cast<float_type>(n * (n+1) * (2*n+1)) / 24.0);
@@ -299,46 +293,32 @@ const Rowsz PLS_Model::optimal_num_components(const Mat2D& X, const Mat2D& Y, co
     }
 
     Mat2D press = Mat2D::Zero(Y.cols(), A);
-    Rowsz min_press_idx = Rowsz::Zero(Y.cols());
-    Row  min_press_val(Y.cols());
-    Rowsz best_comp(Y.cols());
 
     // Determine PRESS values
     for (size_t i = 0; i < static_cast<size_t>(errors.size()); i++) {    // for each Y category
-        for (size_t j = 0; j < static_cast<size_t>(errors[i].rows()); j++) {      // for each observation
-            for (size_t k = 0; k < static_cast<size_t>(errors[i].cols()); k++) {  // for each component
-                press(i,k) += pow(errors[i](j,k), 2);
-            }
+        for (size_t k = 0; k < static_cast<size_t>(errors[i].cols()); k++) {  // for each component
+            // for each observation
+            press(i, k) += errors[i](Eigen::placeholders::all, k).array().square().sum();
         }
     }
 
-    min_press_val = press.col(0);
-    // Find the component number that minimizes PRESS for each Y category
-    for (size_t i = 0; i < static_cast<size_t>(press.rows()); i++) {              // for each Y category
-        for (size_t j = 0; j < static_cast<size_t>(press.cols()); j++) {          // for each component
-            if (press(i,j) < min_press_val(i)) {
-                min_press_val(i) = press(i,j);
-                min_press_idx(i) = j;
-            }
-        }
-    }
-
-    best_comp = min_press_idx.array() + 1; // +1 to convert from index to component number
+    Colsz min_press_idx(press.rows());
+    for (size_t r = 0; r < press.rows(); r++) { press.row(r).minCoeff(&min_press_idx[r]); }
+    Rowsz best_comp = min_press_idx.array() + 1; // +1 to convert from index to component number
     // Find the min number of components that is not significantly
     // different from the min PRESS at alpha = 0.1 for each Y category
     const float_type ALPHA = 0.1;
-    for (size_t i = 0; i < static_cast<size_t>(press.rows()); i++) {              // for each Y category
+    for (size_t i = 0; i < errors.size(); i++) {             // for each Y category
+        Col err1 = errors[i].col(min_press_idx(i));
         for (size_t j = 0; j < min_press_idx(i); j++) {      // for each smaller number of components
-            Col err1 = errors[i].col(min_press_idx(i));
             Col err2 = errors[i].col(j);
-            auto p = wilcoxon(err1, err2);
+            float_type p = wilcoxon(err1, err2);
             if (p > ALPHA) {
-                best_comp(i) = j + 1; // +1 to convert from index to component number
+                best_comp[i] = j + 1; // +1 to convert from index to component number
                 break;
             }
         }
     }
-
     return best_comp;
 };
 

--- a/pls.h
+++ b/pls.h
@@ -39,6 +39,8 @@ using std::complex;
 
 typedef Matrix<float_type, Dynamic, Dynamic> Mat2D;
 typedef Matrix<float_type, Dynamic, 1>  Col;
+typedef Matrix<int, Dynamic, 1>  Coli;
+typedef Matrix<size_t, Dynamic, 1>  Colsz;
 typedef Matrix<float_type, 1, Dynamic>  Row;
 typedef Matrix<int, 1, Dynamic>  Rowi;
 typedef Matrix<size_t, 1, Dynamic>  Rowsz;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,7 +15,7 @@ GSL_LIB ?= -lm -lgsl -lgslcblas -pthread
 
 ABC_INC := -I$(ABCDIR) -I$(SQLDIR) -I$(JSNDIR) -L$(ABCDIR) -labc $(GSL_LIB) -ldl
 
-TESTS := abcutil
+TESTS := abcutil pls
 
 all: ../libabc.a $(TESTS)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,41 @@
+
+default: test_all
+
+# make variable definitions
+CPP := g++
+
+CFLAGS := -O2 -Wall -std=c++17 --pedantic
+SHAREDFLAGS := $(CFLAGS) -fPIC -shared -rdynamic -Wl,--no-as-needed
+
+MKFILE_PATH = $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ABCDIR := $(MKFILE_PATH)/..
+SQLDIR := $(ABCDIR)/sqdb
+JSNDIR := $(ABCDIR)/jsoncpp/include
+GSL_LIB ?= -lm -lgsl -lgslcblas -pthread
+
+ABC_INC := -I$(ABCDIR) -I$(SQLDIR) -I$(JSNDIR) -L$(ABCDIR) -labc $(GSL_LIB) -ldl
+
+TESTS := abcutil
+
+all: ../libabc.a $(TESTS)
+
+%: %.cpp testing.h ../libabc.a
+	$(CPP) $(CFLAGS) $< -o $@ $(ABC_INC)
+
+.FORCE:
+
+../libabc.a: .FORCE
+	$(MAKE) -C $(ABCDIR) -f Makefile
+
+test_all: $(patsubst %,test_%,$(TESTS))
+	@echo tested everything
+	rm $(TESTS)
+
+test_%: %
+	./$^
+
+clean:
+	rm -f $(TESTS)
+
+cleanall: clean
+	$(MAKE) -C $(ABCDIR) clean

--- a/tests/abcutil.cpp
+++ b/tests/abcutil.cpp
@@ -1,0 +1,45 @@
+
+#include "testing.h"
+#include "AbcUtil.h"
+
+// Function to test
+bool test_colwise_z_scores(const Mat2D & test, const Mat2D & target) {
+    Mat2D res = ABC::colwise_z_scores(test);
+    return (target - res).array().square().sum() < 1e-6;
+}
+
+void series_colwise_z_scores() {
+    Mat2D ref = Mat2D(3, 3), stand = Mat2D(3, 3);
+    ref << 1, 1, 1,
+           2, 3, 4,
+           3, 5, 7;
+    stand << -1, -1, -1,
+             0, 0, 0,
+             1, 1, 1;
+    IS_TRUE(test_colwise_z_scores(ref, stand));
+    // TODO more test cases?
+}
+
+bool test_euclidean(const Mat2D & test, const Row & target, const Col & distref) {
+    Col res = ABC::euclidean(test, target);
+    return (res - distref).norm() < 1e-6;
+}
+
+void series_euclidean() {
+    Mat2D ref = Mat2D(2, 2);
+    Row tar = Row(2);
+    Col distref = Col(2);
+    ref << 1, 1,
+           3, 3;
+    tar << 1, 1;
+    distref << 0,
+               2.828427;
+               
+    IS_TRUE(test_euclidean(ref, tar, distref));
+    // TODO more test cases?
+}
+
+int main(void) {
+    series_colwise_z_scores();
+    series_euclidean();
+}

--- a/tests/pls.cpp
+++ b/tests/pls.cpp
@@ -1,0 +1,28 @@
+
+#include "testing.h"
+#include "pls.h"
+
+// Function to test
+bool test_order(const Col & test, const std::vector<size_t> & target) {
+    auto res = ordered(test);
+    bool same = true;
+    for (size_t i = 0; (i < test.size()) & same; i++) {
+        same = same && (res[i] == target[i]);
+    }
+    return same;
+}
+
+void series_order() {
+    Row ref = Row(3);
+    ref << 1, 2, 3;
+    std::vector<size_t> ord = { 0, 1, 2 };
+    IS_TRUE(test_order(ref, ord));
+    ref << 2, 1, 3;
+    ord = { 1, 0, 2 };
+    IS_TRUE(test_order(ref, ord));
+    // TODO more test cases?
+}
+
+int main(void) {
+    series_order();
+}

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -1,0 +1,16 @@
+
+#ifndef TESTING_H
+#define TESTING_H
+
+#include <iostream>
+
+// If macro argument is not true, test is failing
+#define IS_TRUE(x) { \
+    if (!(x)) { \
+        std::cout << __PRETTY_FUNCTION__ << " failed on line " << __LINE__ << std::endl;\
+    } else { \
+        std::cout << __PRETTY_FUNCTION__ << " passed on line " << __LINE__ << std::endl;\
+    } \
+}
+
+#endif


### PR DESCRIPTION
Generally desire:
 - functions that are stateless => easier to test if working correctly
 - "single" steps, with consistent approaches to interface

To this end, transitioning "stateful" functions (that e.g. know about the whole AbcSmc state, rather than the particular mathematical objects relevant to some particular operation) off on AbcSmc object methods into AbcUtil/ABC namespace methods that are stateless. As this happens, reorganizing naming / arguments order / etc to introduce consistency.

Trying to maintiain the commits here such that this PR can be resolved whenever, but haven't grappled with the full scope / checklist of making the above happen.